### PR TITLE
Support json logformatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Flags:
       --slack-username string               slack username for reboot notfications (default "kured")
       --start-time string                   schedule reboot only after this time of day (default "0:00")
       --time-zone string                    use this timezone for schedule inputs (default "UTC")
+      --log-format string                   log format specified as text or json, defaults to "text"
 ```
 
 ### Reboot Sentinel File & Period

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -64,6 +64,7 @@ var (
 	messageTemplateReboot           string
 	podSelectors                    []string
 	rebootCommand                   string
+	logFormat                       string
 
 	rebootDays    []string
 	rebootStart   string
@@ -163,6 +164,9 @@ func main() {
 
 	rootCmd.PersistentFlags().BoolVar(&annotateNodes, "annotate-nodes", false,
 		"if set, the annotations 'weave.works/kured-reboot-in-progress' and 'weave.works/kured-most-recent-reboot-needed' will be given to nodes undergoing kured reboots")
+
+	rootCmd.PersistentFlags().StringVar(&logFormat, "log-format", "text",
+		"use text or json log format")
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
@@ -623,6 +627,10 @@ func parseRebootCommand(rebootCommand string) []string {
 }
 
 func root(cmd *cobra.Command, args []string) {
+	if logFormat == "json" {
+		log.SetFormatter(&log.JSONFormatter{})
+	}
+
 	log.Infof("Kubernetes Reboot Daemon: %s", version)
 
 	nodeID := os.Getenv("KURED_NODE_ID")

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -75,3 +75,4 @@ spec:
 #            - --time-zone=UTC
 #            - --annotate-nodes=false
 #            - --lock-release-delay=30m
+#            - --log-format=text


### PR DESCRIPTION
This commit introduces a new flag '--log-format' that allows a user
to configure json logging on the pods. If the log-format
is not specified, the formatter will default to the existing
text formatter.