### PR TITLE
Change organisation to kubereboot, drop Docker Hub build

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -24,12 +24,6 @@ jobs:
           go-version: "${{ steps.awk_gomod.outputs.version }}"
           check-latest: true
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME_WEAVEWORKSKUREDCI }}
-          password: ${{ secrets.DOCKERHUB_TOKEN_WEAVEWORKSKUREDCI }}
-
       - name: Login to ghcr.io
         uses: docker/login-action@v2
         with:
@@ -56,5 +50,4 @@ jobs:
           platforms: linux/arm64, linux/amd64, linux/arm/v7, linux/arm/v6, linux/386
           push: true
           tags: |
-            docker.io/${{ GITHUB.REPOSITORY }}:main-${{ steps.tags.outputs.sha_short }}
             ghcr.io/${{ GITHUB.REPOSITORY }}:main-${{ steps.tags.outputs.sha_short }}

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -97,7 +97,7 @@ jobs:
           # See https://github.com/goodwithtech/dockle/issues/188
           DOCKLE_HOST: "unix:///var/run/docker.sock"
         with:
-          image-name: docker.io/${{ github.repository_owner }}/kured:${{ github.sha }}
+          image-name: ghcr.io/${{ github.repository_owner }}/kured:${{ github.sha }}
 
   # This ensures the latest code works with the manifests built from tree.
   # It is useful for two things:
@@ -149,7 +149,7 @@ jobs:
           version: v0.14.0
 
       - name: Preload previously built images onto kind cluster
-        run: kind load docker-image docker.io/${{ github.repository_owner }}/kured:${{ github.sha }} --name chart-testing
+        run: kind load docker-image ghcr.io/${{ github.repository_owner }}/kured:${{ github.sha }} --name chart-testing
 
       - name: Do not wait for an hour before detecting the rebootSentinel
         run: |

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -33,13 +33,7 @@ jobs:
           # See https://github.com/goodwithtech/dockle/issues/188
           DOCKLE_HOST: "unix:///var/run/docker.sock"
         with:
-          image-name: docker.io/${{ github.repository_owner }}/kured:${{ steps.tags.outputs.version }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME_WEAVEWORKSKUREDCI }}
-          password: ${{ secrets.DOCKERHUB_TOKEN_WEAVEWORKSKUREDCI }}
+          image-name: ghcr.io/${{ github.repository_owner }}/kured:${{ steps.tags.outputs.version }}
 
       - name: Login to ghcr.io
         uses: docker/login-action@v2
@@ -65,5 +59,4 @@ jobs:
 #          cache-from: type=registry,ref=user/app:buildcache
 #          cache-to: type=inline
           tags: |
-            docker.io/${{ GITHUB.REPOSITORY }}:${{ steps.tags.outputs.version }}
             ghcr.io/${{ GITHUB.REPOSITORY }}:${{ steps.tags.outputs.version }}

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -69,4 +69,4 @@ jobs:
           # See https://github.com/goodwithtech/dockle/issues/188
           DOCKLE_HOST: "unix:///var/run/docker.sock"
         with:
-          image-name: docker.io/${{ github.repository_owner }}/kured:${{ github.sha }}
+          image-name: ghcr.io/${{ github.repository_owner }}/kured:${{ github.sha }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@ helpful for testing. The "building" section in particular makes sense if
 you are planning to contribute code.
 
 [slack]: README.md#getting-help
-[issues]: https://github.com/weaveworks/kured/issues
+[issues]: https://github.com/kubereboot/kured/issues
 [readme]: README.md
 
 ## Certificate of Origin
@@ -39,10 +39,10 @@ Whenever we want to update e.g. the `kubectl` or `client-go` dependencies,
 some RBAC changes might be necessary too.
 
 This is what it took to support Kubernetes 1.14:
-<https://github.com/weaveworks/kured/pull/75>
+<https://github.com/kubereboot/kured/pull/75>
 
 That the process can be more involved that that can be seen in
-<https://github.com/weaveworks/kured/commits/support-k8s-1.10>
+<https://github.com/kubereboot/kured/commits/support-k8s-1.10>
 
 Please update our .github/workflows with the new k8s images, starting by
 the creation of a .github/kind-cluster-<version>.yaml, then updating
@@ -207,7 +207,7 @@ Now create the `kured-<release>-dockerhub.yaml` for e.g. `1.3.0`:
 ```sh
 VERSION=1.3.0
 MANIFEST="kured-$VERSION-dockerhub.yaml"
-make DH_ORG="weaveworks" VERSION="${VERSION}" manifest
+make DH_ORG="kubereboot" VERSION="${VERSION}" manifest
 cat kured-rbac.yaml > "$MANIFEST"
 cat kured-ds.yaml >> "$MANIFEST"
 ```

--- a/Makefile
+++ b/Makefile
@@ -25,19 +25,17 @@ kured-multi:
 build/.image.done: cmd/kured/Dockerfile cmd/kured/kured
 	mkdir -p build
 	cp $^ build
-	$(SUDO) docker build -t docker.io/$(DH_ORG)/kured -f build/Dockerfile ./build
-	$(SUDO) docker tag docker.io/$(DH_ORG)/kured docker.io/$(DH_ORG)/kured:$(VERSION)
-	$(SUDO) docker tag docker.io/$(DH_ORG)/kured ghcr.io/$(DH_ORG)/kured:$(VERSION)
+	$(SUDO) docker build -t ghcr.io/$(DH_ORG)/kured -f build/Dockerfile ./build
+	$(SUDO) docker tag ghcr.io/$(DH_ORG)/kured ghcr.io/$(DH_ORG)/kured:$(VERSION)
 	touch $@
 
 image: build/.image.done
 
 publish-image: image
-	$(SUDO) docker push docker.io/$(DH_ORG)/kured:$(VERSION)
 	$(SUDO) docker push ghcr.io/$(DH_ORG)/kured:$(VERSION)
 
 minikube-publish: image
-	$(SUDO) docker save docker.io/$(DH_ORG)/kured | (eval $$(minikube docker-env) && docker load)
+	$(SUDO) docker save ghcr.io/$(DH_ORG)/kured | (eval $$(minikube docker-env) && docker load)
 
 manifest:
 	sed -i "s#image: docker.io/.*kured.*#image: docker.io/$(DH_ORG)/kured:$(VERSION)#g" kured-ds.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT: all
 .PHONY: all clean image publish-image minikube-publish manifest test tests kured-multi
 
-DH_ORG=weaveworks
+DH_ORG=kubereboot
 VERSION=$(shell git symbolic-ref --short HEAD)-$(shell git rev-parse --short HEAD)
 SUDO=$(shell docker info >/dev/null 2>&1 || echo "sudo -E")
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 :exclamation: We are currently in the middle of the move to a different github organisation.
 If you have an issue with downloading kured images, helm charts, or other information, please
 do not hesitate to contact us in slack (see link below) or in the
-[Migration issue](https://github.com/weaveworks/kured/issues/633).
+[Migration issue](https://github.com/kubereboot/kured/issues/633).
 
 # kured - Kubernetes Reboot Daemon
 
-<img src="https://github.com/weaveworks/kured/raw/main/img/logo.png" align="right"/>
+<img src="https://github.com/kubereboot/kured/raw/main/img/logo.png" align="right"/>
 
 - [kured - Kubernetes Reboot Daemon](#kured---kubernetes-reboot-daemon)
   - [Introduction](#introduction)
@@ -68,7 +68,7 @@ server:
 | 1.1.0 | 1.12.1  | v9.0.0           | release-1.12        | 1.11.x, 1.12.x, 1.13.x            |
 | 1.0.0 | 1.7.6   | v4.0.0           | release-1.7         | 1.6.x, 1.7.x, 1.8.x               |
 
-See the [release notes](https://github.com/weaveworks/kured/releases)
+See the [release notes](https://github.com/kubereboot/kured/releases)
 for specific version compatibility information, including which
 combination have been formally tested.
 
@@ -81,8 +81,8 @@ To obtain a default installation without Prometheus alerting interlock
 or Slack notifications:
 
 ```console
-latest=$(curl -s https://api.github.com/repos/weaveworks/kured/releases | jq -r .[0].tag_name)
-kubectl apply -f "https://github.com/weaveworks/kured/releases/download/$latest/kured-$latest-dockerhub.yaml"
+latest=$(curl -s https://api.github.com/repos/kubereboot/kured/releases | jq -r .[0].tag_name)
+kubectl apply -f "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-dockerhub.yaml"
 ```
 
 If you want to customise the installation, download the manifest and
@@ -300,7 +300,7 @@ Here is the syntax:
 
 - slack:           `slack://tokenA/tokenB/tokenC`
 
-    (`slack://<USERNAME>@tokenA/tokenB/tokenC` - in case you want to [respect username](https://github.com/weaveworks/kured/issues/482))
+    (`slack://<USERNAME>@tokenA/tokenB/tokenC` - in case you want to [respect username](https://github.com/kubereboot/kured/issues/482))
 
     (`--slack-hook-url` is deprecated but possible to use)
 
@@ -410,7 +410,7 @@ Use of `latest` for production deployments is bad practice - see
 [here](https://kubernetes.io/docs/concepts/configuration/overview) for
 details. The manifest on `main` refers to `latest` for local
 development testing with minikube only; for production use choose a
-versioned manifest from the [release page](https://github.com/weaveworks/kured/releases/).
+versioned manifest from the [release page](https://github.com/kubereboot/kured/releases/).
 
 ## Getting Help
 
@@ -418,7 +418,7 @@ If you have any questions about, feedback for or problems with `kured`:
 
 - Invite yourself to the <a href="https://slack.cncf.io/" target="_blank">CNCF Slack</a>.
 - Ask a question on the [#kured](https://cloud-native.slack.com/archives/kured) slack channel.
-- [File an issue](https://github.com/weaveworks/kured/issues/new).
+- [File an issue](https://github.com/kubereboot/kured/issues/new).
 - Join us in [our monthly meeting](https://docs.google.com/document/d/1bsHTjHhqaaZ7yJnXF6W8c89UB_yn-OoSZEmDnIP34n8/edit#),
   every fourth Wednesday of the month at 16:00 UTC.
 

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -32,11 +32,11 @@ import (
 	shoutrrr "github.com/containrrr/shoutrrr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/weaveworks/kured/pkg/alerts"
-	"github.com/weaveworks/kured/pkg/daemonsetlock"
-	"github.com/weaveworks/kured/pkg/delaytick"
-	"github.com/weaveworks/kured/pkg/taints"
-	"github.com/weaveworks/kured/pkg/timewindow"
+	"github.com/kubereboot/kured/pkg/alerts"
+	"github.com/kubereboot/kured/pkg/daemonsetlock"
+	"github.com/kubereboot/kured/pkg/delaytick"
+	"github.com/kubereboot/kured/pkg/taints"
+	"github.com/kubereboot/kured/pkg/timewindow"
 )
 
 var (

--- a/cmd/kured/main_test.go
+++ b/cmd/kured/main_test.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/weaveworks/kured/pkg/alerts"
+	"github.com/kubereboot/kured/pkg/alerts"
 	assert "gotest.tools/v3/assert"
 
 	papi "github.com/prometheus/client_golang/api"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/weaveworks/kured
+module github.com/kubereboot/kured
 
 go 1.18
 


### PR DESCRIPTION
Also drop Docker Hub as discussed.

Areas I did not touch:
- bot name, secrets
- image name
- LICENSE (would need to ask how/if that gets changed...?)
- anything in charts/ - will be handled by separate PR
- one mention in the Dev docs that we used to do some pre-release smoke-testing on the Weave Dev cluster

Signed-off-by: Daniel Holbach <daniel@weave.works>