### PR TITLE
Replace set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
 
       - name: Setup GoReleaser

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup GoReleaser
         run: make bootstrap-tools
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Build image
         run: VERSION="${{ steps.tags.outputs.sha_short }}" make image
@@ -124,7 +124,7 @@ jobs:
       - name: Setup GoReleaser
         run: make bootstrap-tools
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Build artifacts
         run: |

--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
       - name: Find current tag version
-        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup GoReleaser
         run: make bootstrap-tools
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Build artifacts
         run: VERSION="${{ steps.tags.outputs.sha_short }}" make image


### PR DESCRIPTION
Fixes: #685

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: Daniel Holbach <daniel@weave.works>