### PR TITLE
brown paper bag for #686

### DIFF
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
       - name: Find current tag version
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         id: tags
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Signed-off-by: Daniel Holbach <daniel@weave.works>

A mistake on my part.

The complete diff, together with #686 is now:

```diff
diff --git a/.github/workflows/on-main-push.yaml b/.github/workflows/on-main-push.yaml
index 09c2197..343f780 100644
--- a/.github/workflows/on-main-push.yaml
+++ b/.github/workflows/on-main-push.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
 
       - name: Setup GoReleaser
diff --git a/.github/workflows/on-pr.yaml b/.github/workflows/on-pr.yaml
index 71ea50c..bd53f21 100644
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup GoReleaser
         run: make bootstrap-tools
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Build image
         run: VERSION="${{ steps.tags.outputs.sha_short }}" make image
@@ -124,7 +124,7 @@ jobs:
       - name: Setup GoReleaser
         run: make bootstrap-tools
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Build artifacts
         run: |
diff --git a/.github/workflows/on-tag.yaml b/.github/workflows/on-tag.yaml
index d3e7b01..b83ca80 100644
--- a/.github/workflows/on-tag.yaml
+++ b/.github/workflows/on-tag.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version-file: 'go.mod'
           check-latest: true
       - name: Find current tag version
-        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/}"
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         id: tags
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
diff --git a/.github/workflows/periodics-daily.yaml b/.github/workflows/periodics-daily.yaml
index fd08a70..f20811c 100644
--- a/.github/workflows/periodics-daily.yaml
+++ b/.github/workflows/periodics-daily.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup GoReleaser
         run: make bootstrap-tools
       - name: Find current tag version
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: tags
       - name: Build artifacts
         run: VERSION="${{ steps.tags.outputs.sha_short }}" make image


```

Which makes more sense.