### PR TITLE
drop unnecessary replacement for go-restful CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,6 @@ module github.com/kubereboot/kured
 go 1.18
 
 replace (
-	// Fix CVE-2022-1996 (for v2, Go Modules incompatible)
-	github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0+incompatible
-
 	golang.org/x/net => golang.org/x/net v0.4.0
 	golang.org/x/text => golang.org/x/text v0.3.8
 )


### PR DESCRIPTION
Signed-off-by: Daniel Holbach <daniel@weave.works>