### PR TITLE
Feature: Block reboots when regexp matches prometheus alerts

### DIFF
--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -60,6 +60,7 @@ spec:
 #            - --lock-ttl=0
 #            - --prometheus-url=http://prometheus.monitoring.svc.cluster.local
 #            - --alert-filter-regexp=^RebootRequired$
+#            - --alert-filter-match-only=false
 #            - --alert-firing-only=false
 #            - --reboot-sentinel=/var/run/reboot-required
 #            - --prefer-no-schedule-taint=""


### PR DESCRIPTION
Adding "--alert-filter-match-only" argument which inverts the behavior of "alert-filter-regexp". When alert-filter-match-only=true, kured will block on any active alerts that match the regexp defined in 'alert-filter-regexp'.

This is interesting for scenarios where we'll trigger alerts based on total cluster node capacity becoming low (num nodes != Ready has reached a threshold). We can then immediately block kured from continuing to drain and reboot.