### PR TITLE
Release node-lock on blocking pod-selector

### DIFF
--- a/cmd/kured/main_test.go
+++ b/cmd/kured/main_test.go
@@ -4,20 +4,21 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/kubereboot/kured/pkg/alerts"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/kubereboot/kured/pkg/alerts"
 	assert "gotest.tools/v3/assert"
 
 	papi "github.com/prometheus/client_golang/api"
 )
 
 type BlockingChecker struct {
-	blocking bool
+	blocking        bool
+	releaseNodeLock bool
 }
 
-func (fbc BlockingChecker) isBlocked() bool {
-	return fbc.blocking
+func (fbc BlockingChecker) isBlocked() (bool, bool) {
+	return fbc.blocking, fbc.releaseNodeLock
 }
 
 var _ RebootBlocker = BlockingChecker{}       // Verify that Type implements Interface.
@@ -155,7 +156,7 @@ func Test_rebootBlocked(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := rebootBlocked(tt.args.blockers...); got != tt.want {
+			if got, _ := rebootBlocked(tt.args.blockers...); got != tt.want {
 				t.Errorf("rebootBlocked() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
closes #792

When the reboot is blocked by a pod-selector on the node, the node-lock should be released to continue with other nodes. Does not make sense for metric-locks, the old behaviour is kept there.

/cc @dhedberg