### PR TITLE
Adds new flag --metrics-host

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -47,7 +47,7 @@ var (
 	drainTimeout                    time.Duration
 	rebootDelay                     time.Duration
 	period                          time.Duration
-	metricsAddress                  string
+	metricsPort                     int
 	drainGracePeriod                int
 	drainPodSelector                string
 	skipWaitForDeleteTimeoutSeconds int
@@ -126,8 +126,8 @@ func NewRootCommand() *cobra.Command {
 		"node name kured runs on, should be passed down from spec.nodeName via KURED_NODE_ID environment variable")
 	rootCmd.PersistentFlags().BoolVar(&forceReboot, "force-reboot", false,
 		"force a reboot even if the drain fails or times out")
-	rootCmd.PersistentFlags().StringVar(&metricsAddress, "metrics-address", ":8080",
-		"address where metrics will listen")
+	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics-port", 8080,
+		"port number where metrics will listen")
 	rootCmd.PersistentFlags().IntVar(&drainGracePeriod, "drain-grace-period", -1,
 		"time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used")
 	rootCmd.PersistentFlags().StringVar(&drainPodSelector, "drain-pod-selector", "",
@@ -844,5 +844,5 @@ func root(cmd *cobra.Command, args []string) {
 	go maintainRebootRequiredMetric(nodeID, hostSentinelCommand)
 
 	http.Handle("/metrics", promhttp.Handler())
-	log.Fatal(http.ListenAndServe(metricsAddress, nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil))
 }

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -47,6 +47,7 @@ var (
 	drainTimeout                    time.Duration
 	rebootDelay                     time.Duration
 	period                          time.Duration
+	metricsHost                     string
 	metricsPort                     int
 	drainGracePeriod                int
 	drainPodSelector                string
@@ -126,6 +127,8 @@ func NewRootCommand() *cobra.Command {
 		"node name kured runs on, should be passed down from spec.nodeName via KURED_NODE_ID environment variable")
 	rootCmd.PersistentFlags().BoolVar(&forceReboot, "force-reboot", false,
 		"force a reboot even if the drain fails or times out")
+	rootCmd.PersistentFlags().StringVar(&metricsHost, "metrics-host", "",
+		"host where metrics will listen")
 	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics-port", 8080,
 		"port number where metrics will listen")
 	rootCmd.PersistentFlags().IntVar(&drainGracePeriod, "drain-grace-period", -1,
@@ -844,5 +847,5 @@ func root(cmd *cobra.Command, args []string) {
 	go maintainRebootRequiredMetric(nodeID, hostSentinelCommand)
 
 	http.Handle("/metrics", promhttp.Handler())
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, metricsPort), nil))
 }

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -47,7 +47,7 @@ var (
 	drainTimeout                    time.Duration
 	rebootDelay                     time.Duration
 	period                          time.Duration
-	metricsPort                     int
+	metricsAddress                  string
 	drainGracePeriod                int
 	drainPodSelector                string
 	skipWaitForDeleteTimeoutSeconds int
@@ -126,8 +126,8 @@ func NewRootCommand() *cobra.Command {
 		"node name kured runs on, should be passed down from spec.nodeName via KURED_NODE_ID environment variable")
 	rootCmd.PersistentFlags().BoolVar(&forceReboot, "force-reboot", false,
 		"force a reboot even if the drain fails or times out")
-	rootCmd.PersistentFlags().IntVar(&metricsPort, "metrics-port", 8080,
-		"port number where metrics will listen")
+	rootCmd.PersistentFlags().StringVar(&metricsAddress, "metrics-address", ":8080",
+		"address where metrics will listen")
 	rootCmd.PersistentFlags().IntVar(&drainGracePeriod, "drain-grace-period", -1,
 		"time in seconds given to each pod to terminate gracefully, if negative, the default value specified in the pod will be used")
 	rootCmd.PersistentFlags().StringVar(&drainPodSelector, "drain-pod-selector", "",
@@ -844,5 +844,5 @@ func root(cmd *cobra.Command, args []string) {
 	go maintainRebootRequiredMetric(nodeID, hostSentinelCommand)
 
 	http.Handle("/metrics", promhttp.Handler())
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil))
+	log.Fatal(http.ListenAndServe(metricsAddress, nil))
 }

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -83,4 +83,3 @@ spec:
 #            - --annotate-nodes=false
 #            - --lock-release-delay=30m
 #            - --log-format=text
-#            - --metricsAddress=:8080

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -83,3 +83,4 @@ spec:
 #            - --annotate-nodes=false
 #            - --lock-release-delay=30m
 #            - --log-format=text
+#            - --metricsAddress=:8080

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -83,3 +83,5 @@ spec:
 #            - --annotate-nodes=false
 #            - --lock-release-delay=30m
 #            - --log-format=text
+#            - --metrics-host=""
+#            - --metrics-port=8080


### PR DESCRIPTION
Kured runs with `hostNetwork=true`, which means that, today, Kured will expose the metrics endpoint on what is probably a public interface for many deployments. The metrics are generally not sensitive data, but as a policy it seems wrong to do this. Allowing the user to configure which port Kured exposes metrics on is a step in the right direction, but the current implementation does not allow the user to specify the address to listen on. For example, in our use case, we would like for the metrics server to _only_ listen on a loopback address. This would allow us to put [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) in front of the metrics endpoint.

This change could slightly complicate the Helm chart because it not only affects the metrics endpoint, but also the `readinessProbe` configuration.