### PR TITLE
Add signal-reboot

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -182,6 +182,91 @@ jobs:
           ./tests/kind/follow-coordinated-reboot.sh
 
 
+  # This ensures the latest code works with the manifests built from tree.
+  # It is useful for two things:
+  # - Test manifests changes (obviously), ensuring they don't break existing clusters
+  # - Ensure manifests work with the latest versions even with no manifest change
+  #     (compared to helm charts, manifests cannot easily template changes based on versions)
+  # Helm charts are _trailing_ releases, while manifests are done during development.
+  # This test uses the "signal" reboot-method.
+  e2e-manifests-signal:
+    name: End-to-End test with kured with code and manifests from HEAD (signal)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - "1.25"
+          - "1.26"
+          - "1.27"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Ensure go version
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Setup GoReleaser
+        run: make bootstrap-tools
+      - name: Find current tag version
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        id: tags
+      - name: Build artifacts
+        run: |
+          VERSION="${{ steps.tags.outputs.sha_short }}" make image
+          VERSION="${{ steps.tags.outputs.sha_short }}" make manifest
+
+      - name: Workaround "Failed to attach 1 to compat systemd cgroup /actions_job/..." on gh actions
+        run: |
+          sudo bash << EOF
+              cp /etc/docker/daemon.json /etc/docker/daemon.json.old
+              echo '{}' > /etc/docker/daemon.json
+              systemctl restart docker || journalctl --no-pager -n 500
+              systemctl status docker
+          EOF
+
+      # Default name for helm/kind-action kind clusters is "chart-testing"
+      - name: Create kind cluster with 5 nodes
+        uses: helm/kind-action@v1.8.0
+        with:
+          config: .github/kind-cluster-${{ matrix.kubernetes }}.yaml
+          version: v0.14.0
+
+      - name: Preload previously built images onto kind cluster
+        run: kind load docker-image ghcr.io/${{ github.repository }}:${{ steps.tags.outputs.sha_short }} --name chart-testing
+
+      - name: Do not wait for an hour before detecting the rebootSentinel
+        run: |
+          sed -i 's/#\(.*\)--period=1h/\1--period=30s/g' kured-ds-signal.yaml
+
+      - name: Install kured with kubectl
+        run: |
+          kubectl apply -f kured-rbac.yaml && kubectl apply -f kured-ds-signal.yaml
+
+      - name: Ensure kured is ready
+        uses: nick-invision/retry@v2.8.3
+        with:
+          timeout_minutes: 10
+          max_attempts: 10
+          retry_wait_seconds: 60
+          # DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE should all be = to cluster_size
+          command: "kubectl get ds -n kube-system kured | grep -E 'kured.*5.*5.*5.*5.*5'"
+
+      - name: Create reboot sentinel files
+        run: |
+          ./tests/kind/create-reboot-sentinels.sh
+
+      - name: Follow reboot until success
+        env:
+          DEBUG: true
+        run: |
+          ./tests/kind/follow-coordinated-reboot.sh
+
+
 
   # This ensures the latest code works with the manifests built from tree.
   # It is useful for two things:

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -196,9 +196,9 @@ jobs:
       fail-fast: false
       matrix:
         kubernetes:
-          - "1.25"
           - "1.26"
           - "1.27"
+          - "1.28"
     steps:
       - uses: actions/checkout@v3
       - name: Ensure go version

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -105,7 +105,7 @@ jobs:
   # Helm charts are _trailing_ releases, while manifests are done during development.
   # This test uses the "command" reboot-method.
   e2e-manifests-command:
-    name: End-to-End test with kured with code and manifests from HEAD
+    name: End-to-End test with kured with code and manifests from HEAD (command)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -103,7 +103,8 @@ jobs:
   # - Ensure manifests work with the latest versions even with no manifest change
   #     (compared to helm charts, manifests cannot easily template changes based on versions)
   # Helm charts are _trailing_ releases, while manifests are done during development.
-  e2e-manifests:
+  # This test uses the "command" reboot-method.
+  e2e-manifests-command:
     name: End-to-End test with kured with code and manifests from HEAD
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ minikube-publish: image
 
 manifest:
 	sed -i "s#image: ghcr.io/.*kured.*#image: ghcr.io/$(DH_ORG)/kured:$(VERSION)#g" kured-ds.yaml
+	sed -i "s#image: ghcr.io/.*kured.*#image: ghcr.io/$(DH_ORG)/kured:$(VERSION)#g" kured-ds-signal.yaml
 	echo "Please generate combined manifest if necessary"
 
 test:

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -880,8 +880,13 @@ func root(cmd *cobra.Command, args []string) {
 	// To run those commands as it was the host, we'll use nsenter
 	// Relies on hostPID:true and privileged:true to enter host mount space
 	// PID set to 1, until we have a better discovery mechanism.
-	hostSentinelCommand := buildHostCommand(1, sentinelCommand)
 	hostRestartCommand := buildHostCommand(1, restartCommand)
+
+	// Only wrap sentinel-command with nsenter, if a custom-command was configured, otherwise use the host-path mount
+	hostSentinelCommand := sentinelCommand
+	if rebootSentinelCommand != "" {
+		hostSentinelCommand = buildHostCommand(1, sentinelCommand)
+	}
 
 	go rebootAsRequired(nodeID, hostRestartCommand, hostSentinelCommand, window, lockTTL, lockReleaseDelay)
 	go maintainRebootRequiredMetric(nodeID, hostSentinelCommand)

--- a/kured-ds-signal.yaml
+++ b/kured-ds-signal.yaml
@@ -38,11 +38,15 @@ spec:
         - name: kured
           # If you find yourself here wondering why there is no
           # :latest tag on Docker Hub,see the FAQ in the README
-          image: ghcr.io/kubereboot/kured:1.14.2
+          image: ghcr.io/kubereboot/kured:1.13.2
           imagePullPolicy: IfNotPresent
           securityContext:
-            privileged: true # Give permission to nsenter /proc/1/ns/mnt
+            privileged: false # Give permission to nsenter /proc/1/ns/mnt
             readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["*"]
+              add: ["CAP_KILL"]
           ports:
             - containerPort: 8080
               name: metrics
@@ -60,12 +64,12 @@ spec:
           command:
             - /usr/bin/kured
             - --reboot-sentinel=/sentinel/reboot-required
+            - --reboot-method=signal
+#            - --reboot-signal=39
 #            - --force-reboot=false
 #            - --drain-grace-period=-1
 #            - --skip-wait-for-delete-timeout=0
-#            - --drain-delay=0
 #            - --drain-timeout=0
-#            - --drain-pod-selector=""
 #            - --period=1h
 #            - --ds-namespace=kube-system
 #            - --ds-name=kured
@@ -73,12 +77,9 @@ spec:
 #            - --lock-ttl=0
 #            - --prometheus-url=http://prometheus.monitoring.svc.cluster.local
 #            - --alert-filter-regexp=^RebootRequired$
-#            - --alert-filter-match-only=false
 #            - --alert-firing-only=false
 #            - --prefer-no-schedule-taint=""
 #            - --reboot-sentinel-command=""
-#            - --reboot-method=command
-#            - --reboot-signal=39
 #            - --slack-hook-url=https://hooks.slack.com/...
 #            - --slack-username=prod
 #            - --slack-channel=alerting
@@ -97,6 +98,3 @@ spec:
 #            - --annotate-nodes=false
 #            - --lock-release-delay=30m
 #            - --log-format=text
-#            - --metrics-host=""
-#            - --metrics-port=8080
-#            - --concurrency=1

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -29,6 +29,10 @@ spec:
           effect: NoSchedule
       hostPID: true # Facilitate entering the host mount namespace via init
       restartPolicy: Always
+      volumes:
+        - name: sentinel
+          hostPath:
+            path: /var/run
       containers:
         - name: kured
           # If you find yourself here wondering why there is no
@@ -48,6 +52,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /var/run
+              name: sentinel
+              readOnly: true
           command:
             - /usr/bin/kured
 #            - --force-reboot=false

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -55,7 +55,9 @@ spec:
           volumeMounts:
             - mountPath: /var/run
               name: sentinel
-              readOnly: true
+              # This can't be read-only because the service-account-token is mounted within the same directory
+              # This would cause a crash at startup
+              readOnly: false
           command:
             - /usr/bin/kured
 #            - --force-reboot=false

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -53,13 +53,12 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /var/run
+            - mountPath: /sentinel
               name: sentinel
-              # This can't be read-only because the service-account-token is mounted within the same directory
-              # This would cause a crash at startup
-              readOnly: false
+              readOnly: true
           command:
             - /usr/bin/kured
+            - --reboot-sentinel=/sentinel/reboot-required
 #            - --force-reboot=false
 #            - --drain-grace-period=-1
 #            - --skip-wait-for-delete-timeout=0
@@ -75,7 +74,6 @@ spec:
 #            - --alert-filter-regexp=^RebootRequired$
 #            - --alert-filter-match-only=false
 #            - --alert-firing-only=false
-#            - --reboot-sentinel=/var/run/reboot-required
 #            - --prefer-no-schedule-taint=""
 #            - --reboot-sentinel-command=""
 #            - --slack-hook-url=https://hooks.slack.com/...

--- a/pkg/reboot/command.go
+++ b/pkg/reboot/command.go
@@ -1,0 +1,22 @@
+package reboot
+
+import (
+	"github.com/kubereboot/kured/pkg/util"
+	log "github.com/sirupsen/logrus"
+)
+
+type commandRebootMethod struct {
+	nodeID        string
+	rebootCommand []string
+}
+
+func NewCommandReboot(nodeID string, rebootCommand []string) *commandRebootMethod {
+	return &commandRebootMethod{nodeID: nodeID, rebootCommand: rebootCommand}
+}
+
+func (c *commandRebootMethod) Reboot() {
+	log.Infof("Running command: %s for node: %s", c.rebootCommand, c.nodeID)
+	if err := util.NewCommand(c.rebootCommand[0], c.rebootCommand[1:]...).Run(); err != nil {
+		log.Fatalf("Error invoking reboot command: %v", err)
+	}
+}

--- a/pkg/reboot/command.go
+++ b/pkg/reboot/command.go
@@ -5,16 +5,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type commandRebootMethod struct {
+// CommandRebootMethod holds context-information for a command reboot.
+type CommandRebootMethod struct {
 	nodeID        string
 	rebootCommand []string
 }
 
-func NewCommandReboot(nodeID string, rebootCommand []string) *commandRebootMethod {
-	return &commandRebootMethod{nodeID: nodeID, rebootCommand: rebootCommand}
+// NewCommandReboot creates a new command-rebooter which needs full privileges on the host.
+func NewCommandReboot(nodeID string, rebootCommand []string) *CommandRebootMethod {
+	return &CommandRebootMethod{nodeID: nodeID, rebootCommand: rebootCommand}
 }
 
-func (c *commandRebootMethod) Reboot() {
+func (c *CommandRebootMethod) Reboot() {
 	log.Infof("Running command: %s for node: %s", c.rebootCommand, c.nodeID)
 	if err := util.NewCommand(c.rebootCommand[0], c.rebootCommand[1:]...).Run(); err != nil {
 		log.Fatalf("Error invoking reboot command: %v", err)

--- a/pkg/reboot/command.go
+++ b/pkg/reboot/command.go
@@ -16,6 +16,7 @@ func NewCommandReboot(nodeID string, rebootCommand []string) *CommandRebootMetho
 	return &CommandRebootMethod{nodeID: nodeID, rebootCommand: rebootCommand}
 }
 
+// Reboot triggers the command-reboot.
 func (c *CommandRebootMethod) Reboot() {
 	log.Infof("Running command: %s for node: %s", c.rebootCommand, c.nodeID)
 	if err := util.NewCommand(c.rebootCommand[0], c.rebootCommand[1:]...).Run(); err != nil {

--- a/pkg/reboot/reboot.go
+++ b/pkg/reboot/reboot.go
@@ -1,5 +1,6 @@
 package reboot
 
+// Reboot interface defines the Reboot function to be implemented.
 type Reboot interface {
 	Reboot()
 }

--- a/pkg/reboot/reboot.go
+++ b/pkg/reboot/reboot.go
@@ -1,0 +1,5 @@
+package reboot
+
+type Reboot interface {
+	Reboot()
+}

--- a/pkg/reboot/signal.go
+++ b/pkg/reboot/signal.go
@@ -1,0 +1,30 @@
+package reboot
+
+import (
+	"os"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type signalRebootMethod struct {
+	nodeID string
+}
+
+func NewSignalReboot(nodeID string) *signalRebootMethod {
+	return &signalRebootMethod{nodeID: nodeID}
+}
+
+func (c *signalRebootMethod) Reboot() {
+	log.Infof("Emit reboot-signal for node: %s", c.nodeID)
+
+	process, err := os.FindProcess(1)
+	if err != nil {
+		log.Fatalf("There was no systemd process found: %v", err)
+	}
+
+	err = process.Signal(syscall.Signal(34 + 5)) // SIGRTMIN+5
+	if err != nil {
+		log.Fatalf("Signal of SIGRTMIN+5 failed: %v", err)
+	}
+}

--- a/pkg/reboot/signal.go
+++ b/pkg/reboot/signal.go
@@ -7,15 +7,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type signalRebootMethod struct {
+// SignalRebootMethod holds context-information for a signal reboot.
+type SignalRebootMethod struct {
 	nodeID string
+	signal int
 }
 
-func NewSignalReboot(nodeID string) *signalRebootMethod {
-	return &signalRebootMethod{nodeID: nodeID}
+// NewSignalReboot creates a new signal-rebooter which can run unprivileged.
+func NewSignalReboot(nodeID string, signal int) *SignalRebootMethod {
+	return &SignalRebootMethod{nodeID: nodeID, signal: signal}
 }
 
-func (c *signalRebootMethod) Reboot() {
+func (c *SignalRebootMethod) Reboot() {
 	log.Infof("Emit reboot-signal for node: %s", c.nodeID)
 
 	process, err := os.FindProcess(1)
@@ -23,7 +26,7 @@ func (c *signalRebootMethod) Reboot() {
 		log.Fatalf("There was no systemd process found: %v", err)
 	}
 
-	err = process.Signal(syscall.Signal(34 + 5)) // SIGRTMIN+5
+	err = process.Signal(syscall.Signal(c.signal))
 	if err != nil {
 		log.Fatalf("Signal of SIGRTMIN+5 failed: %v", err)
 	}

--- a/pkg/reboot/signal.go
+++ b/pkg/reboot/signal.go
@@ -18,6 +18,7 @@ func NewSignalReboot(nodeID string, signal int) *SignalRebootMethod {
 	return &SignalRebootMethod{nodeID: nodeID, signal: signal}
 }
 
+// Reboot triggers the signal-reboot.
 func (c *SignalRebootMethod) Reboot() {
 	log.Infof("Emit reboot-signal for node: %s", c.nodeID)
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,7 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// newCommand creates a new Command with stdout/stderr wired to our standard logger
+// NewCommand creates a new Command with stdout/stderr wired to our standard logger
 func NewCommand(name string, arg ...string) *exec.Cmd {
 	cmd := exec.Command(name, arg...)
 	cmd.Stdout = log.NewEntry(log.StandardLogger()).

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// newCommand creates a new Command with stdout/stderr wired to our standard logger
+func NewCommand(name string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(name, arg...)
+	cmd.Stdout = log.NewEntry(log.StandardLogger()).
+		WithField("cmd", cmd.Args[0]).
+		WithField("std", "out").
+		WriterLevel(log.InfoLevel)
+
+	cmd.Stderr = log.NewEntry(log.StandardLogger()).
+		WithField("cmd", cmd.Args[0]).
+		WithField("std", "err").
+		WriterLevel(log.WarnLevel)
+
+	return cmd
+}


### PR DESCRIPTION
Based on #813
close #416 
close #722

This PR adds a `--reboot-method` flag with "command" (default) and "signal" option. The "command" option uses the `--reboot-command` on the host with `nsenter` as before. The new "signal" mode uses a `SIGRTMIN+5` signal by default against PID 1 (systemd) to reboot the node. The signal can be changed via `--reboot-signal` flag.

With this, the kured pod runs without privileged mode.

This PR is published as docker-image (amd64 and arm64): `ghcr.io/ckotzbauer/kured:1.14.0-alpha.2`
Usage (based on the latest helm-chart) - Helm values.yaml:

```yaml
image:
  repository: ghcr.io/ckotzbauer/kured
  tag: 1.14.0-alpha.2
updateStrategy: RollingUpdate
configuration:
  period: "0h0m30s"
  rebootDelay: 0h1m0s
  rebootSentinel: /sentinel/reboot-required
extraArgs:
  reboot-method: signal
containerSecurityContext:
  readOnlyRootFilesystem: true
  privileged: false
  allowPrivilegeEscalation: false
  capabilities:
    drop: ["*"]
    add: ["CAP_KILL"]
volumes:
  - name: sentinel
    hostPath:
      path: /var/run
      type: Directory
volumeMounts:
  - name: sentinel
    mountPath: /sentinel
    readOnly: true
```
