### PR TITLE
Release 1.14.0

### DIFF
--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -33,7 +33,7 @@ spec:
         - name: kured
           # If you find yourself here wondering why there is no
           # :latest tag on Docker Hub,see the FAQ in the README
-          image: ghcr.io/kubereboot/kured:1.13.2
+          image: ghcr.io/kubereboot/kured:1.14.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true # Give permission to nsenter /proc/1/ns/mnt
@@ -54,6 +54,7 @@ spec:
 #            - --drain-grace-period=-1
 #            - --skip-wait-for-delete-timeout=0
 #            - --drain-timeout=0
+#            - --drain-pod-selector=""
 #            - --period=1h
 #            - --ds-namespace=kube-system
 #            - --ds-name=kured


### PR DESCRIPTION
# Release notes proposal




## Features and Improvements

- Support pod-selector for drain command (#788)
- Use readOnlyRootFilesystem (#805)
- Log on unusual sentinel-command exit code (#806)
- Don’t hold node lock if reboot is blocked (#819)
- Add argument to invert the behavior of alert-filter-regexp (#786)
- Add multiple concurrent node reboot (#660)
- Adds new flag --metrics-host (#811)


## Build and Testing

- Use go@1.20, k8s@0.27.4, test k8s 1.26-1.28 (#818)
- updated build-tools (#809)
- confirm cosign prompt
- Update alpine to 3.18.3 (#815)


## Kubernetes Version Compatibility

The daemon image contains a 1.27.x k8s.io/{client-go,kubectl} for the purposes of maintaining the lock and draining worker nodes. Kubernetes aims to provide forwards & backwards compatibility of one minor version between client and server, so this should work on 1.26.x, 1.27.x and 1.28.x

Thanks a lot to everyone who contributed to kured since 1.13.2.
