### PR TITLE
feat: add drain delay

### DIFF
--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -53,6 +53,7 @@ spec:
 #            - --force-reboot=false
 #            - --drain-grace-period=-1
 #            - --skip-wait-for-delete-timeout=0
+#            - --drain-delay=0
 #            - --drain-timeout=0
 #            - --drain-pod-selector=""
 #            - --period=1h


### PR DESCRIPTION
This PR adds a `--drain-delay` flag.
The duration given will delay the node draining process to allow for other controllers in the cluster to complete work.

We are using `--pre-reboot-node-labels=node.kubernetes.io/exclude-from-external-load-balancers=true` to signal the load balancer controller to start draining connections from the node as it is about to be drained.
With the flag added we can delay the draining process to ensure the load balancer controller has enough time to remove the node from active traffic flow before the draining starts.