### PR TITLE
Propagate Context

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -426,7 +426,6 @@ func (kb KubernetesBlockingChecker) isBlocked(ctx context.Context) bool {
 }
 
 func rebootBlocked(ctx context.Context, blockers ...RebootBlocker) bool {
-	// TODO: can we do that concurrently
 	for _, blocker := range blockers {
 		if blocker.isBlocked(ctx) {
 			return true

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	k8s.io/kubectl v0.29.4
 )
 
+require github.com/oklog/run v1.1.0
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
 github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=

--- a/pkg/alerts/prometheus.go
+++ b/pkg/alerts/prometheus.go
@@ -36,10 +36,9 @@ func NewPromClient(conf papi.Config) (*PromClient, error) {
 // filter by regexp means when the regex finds the alert-name; the alert is exluded from the
 // block-list and will NOT block rebooting. query by includeLabel means,
 // if the query finds an alert, it will include it to the block-list and it WILL block rebooting.
-func (p *PromClient) ActiveAlerts(filter *regexp.Regexp, firingOnly, filterMatchOnly bool) ([]string, error) {
-
+func (p *PromClient) ActiveAlerts(ctx context.Context, filter *regexp.Regexp, firingOnly, filterMatchOnly bool) ([]string, error) {
 	// get all alerts from prometheus
-	value, _, err := p.api.Query(context.Background(), "ALERTS", time.Now())
+	value, _, err := p.api.Query(ctx, "ALERTS", time.Now())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/alerts/prometheus_test.go
+++ b/pkg/alerts/prometheus_test.go
@@ -1,10 +1,10 @@
 package alerts
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"net/http/httptest"
-
 	"regexp"
 	"testing"
 
@@ -27,7 +27,6 @@ type MockServerProperties struct {
 
 // NewMockServer sets up a new MockServer with properties ad starts the server.
 func NewMockServer(props ...MockServerProperties) *httptest.Server {
-
 	handler := http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			for _, proc := range props {
@@ -140,7 +139,6 @@ func TestActiveAlerts(t *testing.T) {
 		defer mockServer.Close()
 
 		t.Run(tc.it, func(t *testing.T) {
-
 			// regex filter
 			regex, _ := regexp.Compile(tc.rFilter)
 
@@ -150,7 +148,7 @@ func TestActiveAlerts(t *testing.T) {
 				log.Fatal(err)
 			}
 
-			result, err := p.ActiveAlerts(regex, tc.firingOnly, tc.filterMatchOnly)
+			result, err := p.ActiveAlerts(context.Background(), regex, tc.firingOnly, tc.filterMatchOnly)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/reboot/command.go
+++ b/pkg/reboot/command.go
@@ -1,6 +1,8 @@
 package reboot
 
 import (
+	"context"
+
 	"github.com/kubereboot/kured/pkg/util"
 	log "github.com/sirupsen/logrus"
 )
@@ -17,9 +19,9 @@ func NewCommandReboot(nodeID string, rebootCommand []string) *CommandRebootMetho
 }
 
 // Reboot triggers the command-reboot.
-func (c *CommandRebootMethod) Reboot() {
+func (c *CommandRebootMethod) Reboot(ctx context.Context) {
 	log.Infof("Running command: %s for node: %s", c.rebootCommand, c.nodeID)
-	if err := util.NewCommand(c.rebootCommand[0], c.rebootCommand[1:]...).Run(); err != nil {
+	if err := util.NewCommand(ctx, c.rebootCommand[0], c.rebootCommand[1:]...).Run(); err != nil {
 		log.Fatalf("Error invoking reboot command: %v", err)
 	}
 }

--- a/pkg/reboot/reboot.go
+++ b/pkg/reboot/reboot.go
@@ -1,6 +1,8 @@
 package reboot
 
+import "context"
+
 // Reboot interface defines the Reboot function to be implemented.
 type Reboot interface {
-	Reboot()
+	Reboot(context.Context)
 }

--- a/pkg/reboot/signal.go
+++ b/pkg/reboot/signal.go
@@ -1,6 +1,7 @@
 package reboot
 
 import (
+	"context"
 	"os"
 	"syscall"
 
@@ -19,7 +20,7 @@ func NewSignalReboot(nodeID string, signal int) *SignalRebootMethod {
 }
 
 // Reboot triggers the signal-reboot.
-func (c *SignalRebootMethod) Reboot() {
+func (c *SignalRebootMethod) Reboot(_ context.Context) {
 	log.Infof("Emit reboot-signal for node: %s", c.nodeID)
 
 	process, err := os.FindProcess(1)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,14 +1,15 @@
 package util
 
 import (
+	"context"
 	"os/exec"
 
 	log "github.com/sirupsen/logrus"
 )
 
 // NewCommand creates a new Command with stdout/stderr wired to our standard logger
-func NewCommand(name string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(name, arg...)
+func NewCommand(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, arg...)
 	cmd.Stdout = log.NewEntry(log.StandardLogger()).
 		WithField("cmd", cmd.Args[0]).
 		WithField("std", "out").


### PR DESCRIPTION
Propagate a context from the main function to wherever it is needed.

Use `github.com/oklog/run` run groups to handle the life cycle of the go
routines running the rebooter and metrics server.

Ref: https://github.com/kubereboot/kured/issues/234
and https://github.com/kubereboot/kured/pull/808

Signed-off-by: leonnicolas <leonloechner@gmx.de>
