### PR TITLE
Change relative link to absolute link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ In any case, it will make sense to familiarise yourself with the main
 options, which is helpful for testing. The "building" section in
 particular makes sense if you are planning to contribute code.
 
-[slack]: README.md#getting-help
+[slack]: https://github.com/kubereboot/kured/blob/main/README.md#getting-help
 [issues]: https://github.com/kubereboot/kured/issues
 [documentation]: https://kured.dev/docs
 


### PR DESCRIPTION
Without this patch, the copy of the contributing.md into our doc site (generated from [1] and [2]) will refer to a local README.md into the website git repo, which is not existing.

This is a problem, as it generates dead link for lychee on local runs in 'content/en/docs/development.md'.

This fixes it by making the link absolute, while keeping the CONTRIBUTING.md in sync between repos. The alternative would be to edit the site generator in [1]. Yet, I believe having an absolute link does not hurt, because we already use the full git repo in other parts of the same documentation.

[1]: https://github.com/kubereboot/website/blob/5da8aba559460ef7a8c363ab021328cba9e0deda/hack/gen-content.py
[2]: https://github.com/kubereboot/website/blob/5da8aba559460ef7a8c363ab021328cba9e0deda/external-sources/kubereboot/kured