### PR TITLE
update go to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubereboot/kured
 
-go 1.21
+go 1.22
 
 replace golang.org/x/net => golang.org/x/net v0.23.0
 


### PR DESCRIPTION
This PR updates the version of go used to build the project to 1.22.