### PR TITLE
Cleanup dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM alpine:3.20.3 as bin
+FROM alpine:3.20.3 AS bin
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -19,7 +19,7 @@ RUN set -ex \
     esac \
   && cp /dist/kured_${TARGETOS}_${TARGETARCH}${SUFFIX}/kured /dist/kured;
 
-FROM --platform=$TARGETPLATFORM alpine:3.20.3
+FROM alpine:3.20.3
 RUN apk update --no-cache && apk upgrade --no-cache && apk add --no-cache ca-certificates tzdata
 COPY --from=bin /dist/kured /usr/bin/kured
 ENTRYPOINT ["/usr/bin/kured"]


### PR DESCRIPTION
Without this, docker buildx will complain about the
following issues:
- "RedundantTargetPlatform: Setting platform to predefined $TARGETPLATFORM in
   FROM is redundant as this is the default behavior"
- "FromAsCasing: 'as' and 'FROM' keywords' casing do not match"

This fixes it.
