### PR TITLE
add golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+version: "2"
+#timeout : 5m we can add this if needed 
+modules-download-mode: readonly
+run:
+  tests: false
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - unused
+    - contextcheck
+    - goconst
+    - gosec
+    - testifylint
+    - errcheck
+    - revive
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  revive:
+    severity: warning
+    confidence: 0.8
+    rules:
+      - name: indent-error-flow
+      - name: var-naming
+      - name: import-shadowing
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: false
+  sort-results: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,9 @@ linters-settings:
       - name: indent-error-flow
       - name: var-naming
       - name: import-shadowing
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#package-comments
+      - name: package-comments # This is not working!
+        disabled: true
 output:
   format: colored-line-number
   print-issued-lines: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ You can see their contents in `.github/workflows`.
 
 We currently run:
 
-- go tests and lint
+- go tests and golangci-lint
 - `shellcheck`
 - a check for dead links in our docs
 - a security check against our base image (alpine)
@@ -159,6 +159,15 @@ To test your code manually, follow the section Manual testing.
 Please run `make test` to run only the basic tests. It gives a good
 idea of the code behaviour.
 
+### Linting
+
+We use [`golangci-lint`](https://golangci-lint.run/) for Go code linting.
+
+To run lint checks locally:
+
+```bash
+make lint
+```
 ### Manual functional testing
 
 Before `kured` is released, we want to make sure it still works fine on the

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT: all
-.PHONY: all clean image minikube-publish manifest test kured-all
+.PHONY: all clean image minikube-publish manifest test kured-all lint 
 
 HACKDIR=./hack/bin
 GORELEASER_CMD=$(HACKDIR)/goreleaser
@@ -72,3 +72,10 @@ test: bootstrap-tools
 	echo "Running shellcheck"
 	find . -name '*.sh' | xargs -n1 $(HACKDIR)/shellcheck
 	staticcheck ./...
+lint:
+	@echo "Ensuring golangci-lint is installed..."
+	@if ! command -v $(HACKDIR)/golangci-lint > /dev/null; then \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(HACKDIR) v2.1.6; \
+	fi
+	@echo "Running golangci-lint..."
+	$(HACKDIR)/golangci-lint run ./...

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -1,3 +1,6 @@
+// The main controller for kured
+// This package is a reference implementation on how to reboot your nodes based on the different
+// tools present in this project's modules
 package main
 
 import (

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -612,8 +612,8 @@ func rebootAsRequired(nodeID string, rebooter reboot.Rebooter, checker checkers.
 				log.Errorf("Error releasing lock, will retry: %v", err)
 				continue
 			}
-			break
 		}
+		break
 	}
 
 	preferNoScheduleTaint := taints.New(client, nodeID, preferNoScheduleTaintName, v1.TaintEffectPreferNoSchedule)

--- a/internal/validators.go
+++ b/internal/validators.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+
 	"github.com/kubereboot/kured/pkg/checkers"
 	"github.com/kubereboot/kured/pkg/reboot"
 	log "github.com/sirupsen/logrus"
@@ -10,11 +11,11 @@ import (
 // NewRebooter validates the rebootMethod, rebootCommand, and rebootSignal input,
 // then chains to the right constructor.
 func NewRebooter(rebootMethod string, rebootCommand string, rebootSignal int) (reboot.Rebooter, error) {
-	switch {
-	case rebootMethod == "command":
+	switch rebootMethod {
+	case "command":
 		log.Infof("Reboot command: %s", rebootCommand)
 		return reboot.NewCommandRebooter(rebootCommand)
-	case rebootMethod == "signal":
+	case "signal":
 		log.Infof("Reboot signal: %d", rebootSignal)
 		return reboot.NewSignalRebooter(rebootSignal)
 	default:

--- a/internal/validators.go
+++ b/internal/validators.go
@@ -1,3 +1,8 @@
+// Package internal provides convenient tools which shouldn't be in cmd/main
+// It will eventually provide internal validation and chaining logic to select
+// appropriate reboot and sentinel check methods based on configuration.
+// It validates user input and instantiates the correct checker and rebooter implementations
+// for use elsewhere in kured.
 package internal
 
 import (

--- a/pkg/blockers/blockers.go
+++ b/pkg/blockers/blockers.go
@@ -1,3 +1,6 @@
+// Package blockers provides interfaces and implementations for determining
+// whether a system should be prevented to reboot.
+// You can use that package if you fork Kured's main loop.
 package blockers
 
 // RebootBlocked checks that a single block Checker

--- a/pkg/blockers/kubernetespod.go
+++ b/pkg/blockers/kubernetespod.go
@@ -3,6 +3,7 @@ package blockers
 import (
 	"context"
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -23,6 +24,8 @@ type KubernetesBlockingChecker struct {
 	filter []string
 }
 
+// NewKubernetesBlockingChecker creates a new KubernetesBlockingChecker using the provided Kubernetes client,
+// node name, and pod selectors.
 func NewKubernetesBlockingChecker(client *kubernetes.Clientset, nodename string, podSelectors []string) *KubernetesBlockingChecker {
 	return &KubernetesBlockingChecker{
 		client:   client,

--- a/pkg/blockers/prometheus.go
+++ b/pkg/blockers/prometheus.go
@@ -3,13 +3,14 @@ package blockers
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sort"
+	"time"
+
 	papi "github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	log "github.com/sirupsen/logrus"
-	"regexp"
-	"sort"
-	"time"
 )
 
 // Compile-time checks to ensure the type implements the interface
@@ -31,6 +32,8 @@ type PrometheusBlockingChecker struct {
 	promClient papi.Client
 }
 
+// NewPrometheusBlockingChecker creates a new PrometheusBlockingChecker using the given
+// Prometheus API config, alert filter, and filtering options.
 func NewPrometheusBlockingChecker(config papi.Config, alertFilter *regexp.Regexp, firingOnly bool, filterMatchOnly bool) PrometheusBlockingChecker {
 	promClient, _ := papi.NewClient(config)
 

--- a/pkg/checkers/checker.go
+++ b/pkg/checkers/checker.go
@@ -3,11 +3,12 @@ package checkers
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/shlex"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/google/shlex"
+	log "github.com/sirupsen/logrus"
 )
 
 // Checker is the standard interface to use to check
@@ -59,6 +60,7 @@ type CommandChecker struct {
 func (rc CommandChecker) RebootRequired() bool {
 	bufStdout := new(bytes.Buffer)
 	bufStderr := new(bytes.Buffer)
+	// #nosec G204 -- CheckCommand is controlled and validated internally
 	cmd := exec.Command(rc.CheckCommand[0], rc.CheckCommand[1:]...)
 	cmd.Stdout = bufStdout
 	cmd.Stderr = bufStderr

--- a/pkg/checkers/checker.go
+++ b/pkg/checkers/checker.go
@@ -1,3 +1,9 @@
+// Package checkers provides interfaces and implementations for determining
+// whether a system reboot is required. It includes checkers based on file
+// presence or custom commands, and supports privileged command execution
+// in containerized environments. These checkers are used by kured to
+// detect conditions that should trigger node reboots.
+// You can use that package if you fork Kured's main loop.
 package checkers
 
 import (

--- a/pkg/daemonsetlock/daemonsetlock.go
+++ b/pkg/daemonsetlock/daemonsetlock.go
@@ -1,3 +1,7 @@
+// Package daemonsetlock provides mechanisms for leader election and locking
+// using Kubernetes DaemonSets. It enables distributed coordination of operations
+// (such as reboots) by ensuring only one node acts as the leader at any time,
+// leveraging Kubernetes primitives for safe, atomic locking in clusters.
 package daemonsetlock
 
 import (

--- a/pkg/delaytick/delaytick.go
+++ b/pkg/delaytick/delaytick.go
@@ -10,6 +10,7 @@ func New(s rand.Source, d time.Duration) <-chan time.Time {
 	c := make(chan time.Time)
 
 	go func() {
+		// #nosec G404 -- math/rand is used here for non-security timing jitter
 		random := rand.New(s)
 		time.Sleep(time.Duration(float64(d)/2 + float64(d)*random.Float64()))
 		c <- time.Now()

--- a/pkg/delaytick/delaytick.go
+++ b/pkg/delaytick/delaytick.go
@@ -1,3 +1,9 @@
+// Package delaytick provides utilities for scheduling periodic events
+// with an initial randomized delay. It is primarily used to delay the
+// start of regular ticks, helping to avoid thundering herd problems
+// when multiple nodes begin operations simultaneously.
+// You can use that a random ticker in other projects, but there is
+// no garantee that it will stay (initial plan was to move it to internal)
 package delaytick
 
 import (

--- a/pkg/reboot/command.go
+++ b/pkg/reboot/command.go
@@ -3,10 +3,11 @@ package reboot
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/shlex"
-	log "github.com/sirupsen/logrus"
 	"os/exec"
 	"strings"
+
+	"github.com/google/shlex"
+	log "github.com/sirupsen/logrus"
 )
 
 // CommandRebooter holds context-information for a reboot with command
@@ -20,7 +21,7 @@ func (c CommandRebooter) Reboot() error {
 
 	bufStdout := new(bytes.Buffer)
 	bufStderr := new(bytes.Buffer)
-	cmd := exec.Command(c.RebootCommand[0], c.RebootCommand[1:]...)
+	cmd := exec.Command(c.RebootCommand[0], c.RebootCommand[1:]...) // #nosec G204
 	cmd.Stdout = bufStdout
 	cmd.Stderr = bufStderr
 

--- a/pkg/reboot/reboot.go
+++ b/pkg/reboot/reboot.go
@@ -1,3 +1,7 @@
+// Package reboot provides mechanisms to trigger node reboots using different
+// methods, like custom commands or signals.
+// Each of those includes constructors and interfaces for handling different reboot
+// strategies, supporting privileged command execution via nsenter for containerized environments.
 package reboot
 
 // Rebooter is the standard interface to use to execute

--- a/pkg/taints/taints.go
+++ b/pkg/taints/taints.go
@@ -1,3 +1,6 @@
+// Package taints provides utilities to manage Kubernetes node taints for controlling
+// pod scheduling and execution. It allows setting, removing, and checking taints on nodes,
+// using Kubernetes client-go and JSON patching for atomic updates.
 package taints
 
 import (

--- a/pkg/timewindow/days.go
+++ b/pkg/timewindow/days.go
@@ -50,7 +50,7 @@ func parseWeekdays(days []string) (weekdays, error) {
 		if err != nil {
 			return weekdays(0), err
 		}
-
+		// #nosec G115 -- weekday is guaranteed to be between 0–6 by parseWeekday()
 		result |= 1 << uint32(weekday)
 	}
 
@@ -59,6 +59,7 @@ func parseWeekdays(days []string) (weekdays, error) {
 
 // Contains returns true if the specified weekday is a member of this set.
 func (w weekdays) Contains(day time.Weekday) bool {
+	// #nosec G115 -- day is time.Weekday [0-6], shift safe within uint32
 	return uint32(w)&(1<<uint32(day)) != 0
 }
 

--- a/pkg/timewindow/timewindow.go
+++ b/pkg/timewindow/timewindow.go
@@ -1,3 +1,7 @@
+// Package timewindow provides utilities for handling days of the week,
+// including parsing, representing, and manipulating sets of weekdays.
+// It enables flexible specification of time windows for reboot operations
+// in kured, supporting various formats and convenience functions.
 package timewindow
 
 import (


### PR DESCRIPTION
### Description  
This PR addresses issue #1135.

### How?  
- Adds a `golangci-lint` configuration file (`.golangci.yml`) to standardize linting rules.  
- Updates the Makefile to install and run `golangci-lint` via `make lint`. 