### PR TITLE
Fix all references to /var/run to just be /run

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Kured (KUbernetes REboot Daemon) is a Kubernetes daemonset that
 performs safe automatic node reboots when the need to do so is
 indicated by the package management system of the underlying OS.
 
-- Watches for the presence of a reboot sentinel file e.g. `/var/run/reboot-required`
+- Watches for the presence of a reboot sentinel file e.g. `/run/reboot-required`
   or the successful run of a sentinel command.
 - Utilises a lock in the API server to ensure only one node reboots at
   a time

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -154,7 +154,7 @@ func main() {
 		"Only block if the alert-filter-regexp matches active alerts")
 	flag.BoolVar(&alertFiringOnly, "alert-firing-only", false,
 		"only consider firing alerts when checking for active alerts")
-	flag.StringVar(&rebootSentinelFile, "reboot-sentinel", "/var/run/reboot-required",
+	flag.StringVar(&rebootSentinelFile, "reboot-sentinel", "/run/reboot-required",
 		"path to file whose existence triggers the reboot command")
 	flag.StringVar(&preferNoScheduleTaintName, "prefer-no-schedule-taint", "",
 		"Taint name applied during pending node reboot (to prevent receiving additional pods from other rebooting nodes). Disabled by default. Set e.g. to \"weave.works/kured-node-reboot\" to enable tainting.")

--- a/kured-ds-signal.yaml
+++ b/kured-ds-signal.yaml
@@ -32,7 +32,7 @@ spec:
       volumes:
         - name: sentinel
           hostPath:
-            path: /var/run
+            path: /run
             type: Directory
       containers:
         - name: kured

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -32,7 +32,7 @@ spec:
       volumes:
         - name: sentinel
           hostPath:
-            path: /var/run
+            path: /run
             type: Directory
       containers:
         - name: kured

--- a/tests/kind/testfiles/create-reboot-sentinels.sh
+++ b/tests/kind/testfiles/create-reboot-sentinels.sh
@@ -7,5 +7,5 @@ kubectl_flags=( )
 for nodename in $(${KUBECTL_CMD:-kubectl} "${kubectl_flags[@]}" get nodes -o name | grep -v control-plane); do
     echo "Creating reboot sentinel on $nodename"
     docker exec "${nodename/node\//}" hostname
-    docker exec "${nodename/node\//}" touch "${SENTINEL_FILE:-/var/run/reboot-required}"
+    docker exec "${nodename/node\//}" touch "${SENTINEL_FILE:-/run/reboot-required}"
 done

--- a/tests/kind/testfiles/podblocker.sh
+++ b/tests/kind/testfiles/podblocker.sh
@@ -34,7 +34,7 @@ spec:
     blocked-host: "yes"
 EOF
 
-docker exec "$worker" touch "${SENTINEL_FILE:-/var/run/reboot-required}"
+docker exec "$worker" touch "${SENTINEL_FILE:-/run/reboot-required}"
 
 set -o errexit
 max_attempts="100"


### PR DESCRIPTION
On any modern system `/var/run` should just be a compat symlink to `/run`.

For this project it's probably fine as is, but it can matter in cases where the compat symlink might not be present yet.