### PR TITLE
Add configuration to block on node labels

### DIFF
--- a/kured-ds-signal.yaml
+++ b/kured-ds-signal.yaml
@@ -90,6 +90,7 @@ spec:
 #            - --blocking-pod-selector=runtime=long,cost=expensive
 #            - --blocking-pod-selector=name=temperamental
 #            - --blocking-pod-selector=...
+#            - --blocking-node-label=kubernetes.io/arch:arm64
 #            - --reboot-days=sun,mon,tue,wed,thu,fri,sat
 #            - --reboot-delay=90s
 #            - --start-time=0:00

--- a/kured-ds.yaml
+++ b/kured-ds.yaml
@@ -89,6 +89,7 @@ spec:
 #            - --blocking-pod-selector=runtime=long,cost=expensive
 #            - --blocking-pod-selector=name=temperamental
 #            - --blocking-pod-selector=...
+#            - --blocking-node-label=kubernetes.io/arch:arm64
 #            - --reboot-days=sun,mon,tue,wed,thu,fri,sat
 #            - --reboot-delay=90s
 #            - --start-time=0:00

--- a/pkg/blockers/kubernetesnode.go
+++ b/pkg/blockers/kubernetesnode.go
@@ -1,0 +1,106 @@
+package blockers
+
+import (
+	"context"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// nodeFilter is a Kubernetes label that can optionally have a value
+type nodeFilter struct {
+	name  string
+	value string
+}
+
+// IsFilterMatch determines if a requested label filter matches our node label.
+func (nf nodeFilter) IsFilterMatch(label, val string) bool {
+	match := false
+
+	if label == nf.name {
+		match = true
+
+		if nf.value != "" && val != nf.value {
+			match = false
+		}
+	}
+
+	return match
+}
+
+// parseFilter gets a nodeFilter from an input string
+func parseFilter(label string) nodeFilter {
+	parts := strings.Split(label, ":")
+
+	nf := nodeFilter{
+		name: strings.TrimSpace(parts[0]),
+	}
+
+	if len(parts) > 1 {
+		nf.value = strings.TrimSpace(parts[1])
+	}
+
+	return nf
+}
+
+// Compile-time checks to ensure the type implements the interface
+var (
+	_ RebootBlocker = (*KubernetesNodeBlockingChecker)(nil)
+)
+
+// KubernetesNodeBlockingChecker contains info for connecting
+// to k8s, and can give info about whether a reboot should be blocked
+// based on the presence of node labels.
+type KubernetesNodeBlockingChecker struct {
+	// client used to contact kubernetes API
+	client   kubernetes.Interface
+	nodeName string
+	// matching node labels to block
+	filters []nodeFilter
+}
+
+// NewKubernetesNodeBlockingChecker creates a new KubernetesNodeBlockingChecker using the provided Kubernetes client,
+// node name, and label selectors.
+func NewKubernetesNodeBlockingChecker(client kubernetes.Interface, nodename string, labelSelectors []string) *KubernetesNodeBlockingChecker {
+	knb := &KubernetesNodeBlockingChecker{
+		client:   client,
+		nodeName: nodename,
+	}
+
+	for _, filter := range labelSelectors {
+		nodeFilter := parseFilter(filter)
+		knb.filters = append(knb.filters, nodeFilter)
+	}
+
+	return knb
+}
+
+// IsBlocked for the KubernetesNodeBlockingChecker will check if a node has matching labels and
+// if so, block the reboot. It will warn in the logs about blocking, but does not return an error.
+func (knb KubernetesNodeBlockingChecker) IsBlocked() bool {
+	// Avoid making calls if nothing has been set to filter on
+	if len(knb.filters) == 0 {
+		return false
+	}
+
+	// Get this node to inspect its labels
+	node, err := knb.client.CoreV1().Nodes().Get(context.Background(), knb.nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Warnf("Reboot blocked: node query error: %v", err)
+		return true
+	}
+
+	// Check against each provided filter to see if it matches what is set
+	for label, val := range node.Labels {
+		for _, filter := range knb.filters {
+			if filter.IsFilterMatch(label, val) {
+				log.Warnf("Reboot blocked: matching labels: %s:%s", label, val)
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/blockers/kubernetesnode_test.go
+++ b/pkg/blockers/kubernetesnode_test.go
@@ -1,0 +1,109 @@
+package blockers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeLabelFiltering(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-node",
+				Labels: map[string]string{
+					"kubernetes.io/arch":       "amd64",
+					"kubernetes.io/hostname":   "test-node",
+					"kubernetes.io/os":         "linux",
+					"custom.label/dont-reboot": "",
+				},
+			},
+		})
+
+	for _, tc := range []struct {
+		name        string
+		filters     []string
+		shouldBlock bool
+	}{
+		{
+			name:        "doesn't block on no label filters",
+			filters:     []string{},
+			shouldBlock: false,
+		},
+		{
+			name: "blocks when label exists",
+			filters: []string{
+				"custom.label/dont-reboot",
+			},
+			shouldBlock: true,
+		},
+		{
+			name: "blocks when label value matches",
+			filters: []string{
+				"kubernetes.io/arch:amd64",
+			},
+			shouldBlock: true,
+		},
+		{
+			name: "blocks when any matches",
+			filters: []string{
+				"nvidia.com/gpu.present:true",
+				"kubernetes.io/arch:amd64",
+			},
+			shouldBlock: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			knb := KubernetesNodeBlockingChecker{
+				client:   client,
+				nodeName: "test-node",
+			}
+
+			for _, filter := range tc.filters {
+				knb.filters = append(knb.filters, parseFilter(filter))
+			}
+
+			assert.Equal(t, tc.shouldBlock, knb.IsBlocked())
+		})
+	}
+}
+
+func TestNodeLabel(t *testing.T) {
+	label := "kubernetes.io/os"
+	val := "linux"
+
+	for _, tc := range []struct {
+		name         string
+		filter       string
+		shouldFilter bool
+	}{
+		{
+			name:         "filter match on name and value",
+			filter:       "kubernetes.io/os:linux",
+			shouldFilter: true,
+		},
+		{
+			name:         "filter match when label exists",
+			filter:       "kubernetes.io/os",
+			shouldFilter: true,
+		},
+		{
+			name:         "filter doesn't match different label",
+			filter:       "kubernetes.io/arch:amd64",
+			shouldFilter: false,
+		},
+		{
+			name:         "filter doesn't match different values",
+			filter:       "kubernetes.io/os:windows",
+			shouldFilter: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := parseFilter(tc.filter)
+			assert.Equal(t, tc.shouldFilter, filter.IsFilterMatch(label, val))
+		})
+	}
+}


### PR DESCRIPTION
This proposes adding a new configuration setting to be able to block reboots on nodes that have matching labels applied, similar to the pod selector and annotation locking.

The user can specify one or more `--block-node-label` parameters, using the same kubectl label selector format to match and block on whether a label is present (e.g. `my.custom.label`) or if the label is set to a specific value (e.g. `my.custom.label:block-reboots`).