### PR TITLE
Bump GoReleaser to version 2

### DIFF
--- a/.config/goreleaser.yml
+++ b/.config/goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: kured
 before:
   hooks:
@@ -23,10 +24,10 @@ builds:
       - -trimpath
 
 snapshot:
-  name_template: "{{ .ShortCommit }}"
+  version_template: "{{ .ShortCommit }}"
 
 release:
   disable: true
 
 changelog:
-  skip: true
+  disable: true

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 cosign = "2.2.3"
 golangci-lint = "2.1.6"
-goreleaser = "1.24.0"
+goreleaser = "2.12.5"
 kind = "0.30.0"
 kubectl = "1.31.0"
 shellcheck = "0.11.0"

--- a/.github/workflows/on-pr-goreleaser.yaml
+++ b/.github/workflows/on-pr-goreleaser.yaml
@@ -1,0 +1,26 @@
+name: Verify GoReleaser config
+on:
+  pull_request:
+    paths:
+      - '.config/goreleaser.yml'
+  push:
+    paths:
+      - '.config/goreleaser.yml'
+
+jobs:
+  check-goreleaser-config:
+    name: Check GoReleaser config
+    runs-on: ubuntu-latest
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+    - name: Check GoReleaser config
+      uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a #v6.4.0
+      with:
+        version: 'v2.12.5'
+        args: check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Your system needs at least the following binaries installed:
 ### Fetch the additional binaries required
 
 Please run `make install-tools` once on a fresh repository clone to download necessary developer tools.
-Installed tools are listed in [.mise directory](.mise/config.toml).
+Installed tools are listed in [.mise directory](.config/mise.toml).
 
 ### Configure your git for the "Certificate of Origin"
 
@@ -94,7 +94,7 @@ We also have other tests:
 
 All these tests are run on every PR/tagged release. See [.github/workflows](.github/workflows) for more details.
 
-We use [GoReleaser to build](.goreleaser.yml).
+We use [GoReleaser to build](.config/goreleaser.yml).
 
 ## Regular development activities / maintenance
 

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ lint:
 lint-docs:
 	@echo "Running lychee"
 	mise x lychee@latest -- lychee --verbose --no-progress '*.md' '*.yaml' '*/*/*.go' --exclude-link-local
+
+lint-goreleaser:
+	@echo "Checking goreleaser"
+	goreleaser check


### PR DESCRIPTION
This PR is a the first step for https://github.com/kubereboot/kured/issues/1225.
In this PR the following have been done:
1. Migrate GoReleaser to version 2 and modified configs a bit to support it
2. Moved Mise config and GoReleaser config to .config directory to streamline directories
3. Added GitHub Actions Workflow / make to check GoReleaser file on every release for validity