### PR TITLE
fix: bump go version to fix vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubereboot/kured
 
-go 1.24.6
+go 1.24.9
 
 require (
 	github.com/containrrr/shoutrrr v0.8.0


### PR DESCRIPTION
This PR bumps go version to fix security vulnerabilities that causes actions to fail. 

Note: Backporting for v1 https://github.com/kubereboot/kured/pull/1247