### PR TITLE
Stop GitHub actions from auto-closing PRs with keep label

### DIFF
--- a/.github/workflows/periodics-weekly.yaml
+++ b/.github/workflows/periodics-weekly.yaml
@@ -50,6 +50,7 @@ jobs:
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         exempt-issue-labels: 'good first issue,keep'
+        exempt-pr-labels: 'keep'
         days-before-close: 21
 
   check-docs-links:


### PR DESCRIPTION
e.g.: https://github.com/kubereboot/kured/pull/1145