### PR TITLE
Bump goreleaser to version 2

### DIFF
--- a/.config/goreleaser.yaml
+++ b/.config/goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: kured
 before:
   hooks:
@@ -23,10 +24,10 @@ builds:
       - -trimpath
 
 snapshot:
-  name_template: "{{ .ShortCommit }}"
+  version_template: "{{ .ShortCommit }}"
 
 release:
   disable: true
 
 changelog:
-  skip: true
+  disable: true

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 cosign = "2.2.3"
 golangci-lint = "2.1.6"
-goreleaser = "1.24.0"
+goreleaser = "2.13.1"
 kind = "0.30.0"
 kubectl = "1.31.0"
 shellcheck = "0.11.0"

--- a/.github/workflows/on-pr-goreleaser.yaml
+++ b/.github/workflows/on-pr-goreleaser.yaml
@@ -1,0 +1,28 @@
+name: Verify GoReleaser config
+on:
+  pull_request:
+    paths:
+      - '.config/goreleaser.yaml'
+  push:
+    paths:
+      - '.config/goreleaser.yaml'
+
+jobs:
+  check-goreleaser-config:
+    name: Check GoReleaser config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a #v6.4.0
+        with:
+          version: '~> v2'
+          args: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Your system needs at least the following binaries installed:
 ### Fetch the additional binaries required
 
 Please run `make install-tools` once on a fresh repository clone to download necessary developer tools.
-Installed tools are listed in [.mise directory](.mise/config.toml).
+Installed tools are listed in [.mise directory](.config/mise.toml).
 
 ### Configure your git for the "Certificate of Origin"
 
@@ -94,7 +94,7 @@ We also have other tests:
 
 All these tests are run on every PR/tagged release. See [.github/workflows](.github/workflows) for more details.
 
-We use [GoReleaser to build](.goreleaser.yml).
+We use [GoReleaser to build](.config/goreleaser.yaml).
 
 ## Regular development activities / maintenance
 

--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,7 @@ lint:
 lint-docs:
 	@echo "Running lychee"
 	mise x lychee@latest -- lychee --verbose --no-progress '*.md' '*.yaml' '*/*/*.go' --exclude-link-local
+
+lint-goreleaser:
+	@echo "Checking goreleaser"
+	goreleaser check


### PR DESCRIPTION
https://github.com/kubereboot/kured/pull/1264 should be merged before this.
Replaces https://github.com/kubereboot/kured/pull/1230 to fix docker build issues.