### PR TITLE
Remove "next" test

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -103,7 +103,6 @@ jobs:
         kubernetes_version:
           - "previous"
           - "current"
-          - "next"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0


### PR DESCRIPTION
During the policy change removing our "lagging behind", implemented in 168fe81bb40715b28a51e56ef10804e4275ff64c [1], we forgot to remove one "next" test.

This should fix it.

[1]: https://github.com/kubereboot/kured/commit/168fe81bb40715b28a51e56ef10804e4275ff64c