### PR TITLE
Bump go version

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,5 +1,6 @@
 [tools]
 cosign = "2.2.3"
+go = "1.25"
 golangci-lint = "2.7.2"
 goreleaser = "1.24.0"
 kind = "0.31.0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubereboot/kured
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/containrrr/shoutrrr v0.8.0


### PR DESCRIPTION
Without this, our scanners will mark us as impacted by the CVEs:
- CVE-2026-32280
- CVE-2026-32281
- CVE-2026-32283
- CVE-2026-33811
- CVE-2026-33814
- CVE-2026-39820
- CVE-2026-39836
- CVE-2026-42499

None of those should have an impact on us, but it triggers the scanner.