### PR TITLE
Alter bumping work of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      all:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
Without this, dependabot would separate all the dependencies in different PRs.

This is inefficient: The only group of PRs that need to be separate, is kubernetes: We only want to bump them for a new release.

On top of that, those kubernetes dependencies also need to be bumped together.

This fixes the dependabot config to match that use case.