### PR TITLE
Remove the redundant DH_ORG environment variable 

### DIFF
--- a/.config/goreleaser.yaml
+++ b/.config/goreleaser.yaml
@@ -5,7 +5,7 @@ project_name: kured
 before:
   hooks:
     - go mod tidy
-    - sh .config/goreleaser/render-manifest.sh {{ .Version }} ghcr.io/{{ .Env.IMAGE_NAME }}
+    - sh .config/goreleaser/render-manifest.sh {{ .Version }} {{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}
 
 builds:
   - id: kured
@@ -46,7 +46,7 @@ dockers_v2:
     ids:
       - kured
     images:
-      - "ghcr.io/{{ .Env.IMAGE_NAME }}"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE_NAME }}"
     tags:
       - "{{ if ne .Tag .ShortCommit }}{{ .Tag }}{{ end }}"
       - "{{ .ShortCommit }}"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT: all
 .PHONY: all clean install-tools dev-image release dev-manifest e2e-test minikube-publish test lint lint-docs
 
-DH_ORG ?= kubereboot
-IMAGE_NAME ?= $(DH_ORG)/kured
+REGISTRY ?= ghcr.io
+IMAGE_NAME ?= kubereboot/kured
 VERSION ?= $(shell git rev-parse --short HEAD)
 GORELEASER_CONFIG ?= .config/goreleaser.yaml
 GOLANGCI_CONFIG ?= .config/golangci.yaml
@@ -21,7 +21,7 @@ clean:
 	rm -rf ./dist ./.tmp/goreleaser
 
 release:
-	IMAGE_NAME="$(IMAGE_NAME)" goreleaser release --clean -f $(GORELEASER_CONFIG)
+	REGISTRY="$(REGISTRY)" IMAGE_NAME="$(IMAGE_NAME)" goreleaser release --clean -f $(GORELEASER_CONFIG)
 
 dev-image:
 	mkdir -p dist/docker/$(LOCAL_PLATFORM)


### PR DESCRIPTION
In this PR:
1. DH_ORG environment variable has been removed as it's only used in the makefile to generate image name
2. Added registry as a configurable variable in case someone is using a registry other than GitHub.

BREAKING-CHANGE: This breaks the existing development environment where DH_ORG and IMAGE_NAME was configured. This should be changed in development machines. Can document the same in the developer documentation. 