### PR TITLE
Remove trivy cache from checkout folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .tmp/goreleaser
 test.json
 tests/kind/testfiles/*.yaml
+/.cache/


### PR DESCRIPTION
The release process is producing a local image and scanning it
with trivy before continuing the process.

As trivy is by default having its cache in the checked out folder
for the code, the git repository ends up having content, and
considered dirty by goreleaser.

This is a problem, as goreleaser does not want to release if the
git tree is dirty.

This fixes it by ignoring all changes in .cache folder.

Signed-off-by: Jean-Philippe Evrard <open-source@a.spamming.party>
