### PR TITLE
fix: reject node labels not in key=value form to prevent uncordon panic

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -222,6 +223,12 @@ func main() {
 
 	err := validateNodeLabels(preRebootNodeLabels, postRebootNodeLabels)
 	if err != nil {
+		// A malformed label (not in key=value form) would panic later during
+		// uncordon, so refuse to start. A mere key mismatch between the pre and
+		// post reboot sets is only surprising, not fatal, so keep warning.
+		if errors.Is(err, errMalformedNodeLabel) {
+			log.Fatal(err.Error())
+		}
 		log.Warn(err.Error())
 	}
 
@@ -292,16 +299,24 @@ func main() {
 	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, metricsPort), nil)) // #nosec G114
 }
 
+// Sentinel errors for node label validation so callers can tell a malformed
+// label (unsafe, panics later during uncordon) apart from a mere key mismatch
+// between the pre and post reboot sets (surprising but not fatal).
+var (
+	errMalformedNodeLabel      = errors.New("malformed node label")
+	errMismatchedNodeLabelKeys = errors.New("pre/post reboot node label keys do not match")
+)
+
 // splitNodeLabel parses a "key=value" node label into its key and value. It
-// returns an error for any label that is not in key=value form so a malformed
-// entry is caught at startup instead of triggering an index-out-of-range panic
-// later when the labels are applied (see kubereboot/kured#1281). An empty value
-// (for example "some/label=") is allowed since Kubernetes permits empty label
-// values.
+// wraps errMalformedNodeLabel for any label that is not in key=value form so a
+// malformed entry is caught at startup instead of triggering an
+// index-out-of-range panic later when the labels are applied (see
+// kubereboot/kured#1281). An empty value (for example "some/label=") is allowed
+// since Kubernetes permits empty label values.
 func splitNodeLabel(label string) (key, value string, err error) {
 	parts := strings.SplitN(label, "=", 2)
 	if len(parts) != 2 || parts[0] == "" {
-		return "", "", fmt.Errorf("node label %q must be in key=value form", label)
+		return "", "", fmt.Errorf("%w: %q must be in key=value form", errMalformedNodeLabel, label)
 	}
 	return parts[0], parts[1], nil
 }
@@ -325,7 +340,7 @@ func validateNodeLabels(preRebootNodeLabels []string, postRebootNodeLabels []str
 	sort.Strings(preRebootNodeLabelKeys)
 	sort.Strings(postRebootNodeLabelKeys)
 	if !reflect.DeepEqual(preRebootNodeLabelKeys, postRebootNodeLabelKeys) {
-		return fmt.Errorf("pre-reboot-node-labels keys and post-reboot-node-labels keys do not match, resulting in unexpected behaviour")
+		return fmt.Errorf("%w, resulting in unexpected behaviour", errMismatchedNodeLabelKeys)
 	}
 
 	return nil

--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -292,13 +292,35 @@ func main() {
 	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", metricsHost, metricsPort), nil)) // #nosec G114
 }
 
+// splitNodeLabel parses a "key=value" node label into its key and value. It
+// returns an error for any label that is not in key=value form so a malformed
+// entry is caught at startup instead of triggering an index-out-of-range panic
+// later when the labels are applied (see kubereboot/kured#1281). An empty value
+// (for example "some/label=") is allowed since Kubernetes permits empty label
+// values.
+func splitNodeLabel(label string) (key, value string, err error) {
+	parts := strings.SplitN(label, "=", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return "", "", fmt.Errorf("node label %q must be in key=value form", label)
+	}
+	return parts[0], parts[1], nil
+}
+
 func validateNodeLabels(preRebootNodeLabels []string, postRebootNodeLabels []string) error {
 	var preRebootNodeLabelKeys, postRebootNodeLabelKeys []string
 	for _, label := range preRebootNodeLabels {
-		preRebootNodeLabelKeys = append(preRebootNodeLabelKeys, strings.Split(label, "=")[0])
+		key, _, err := splitNodeLabel(label)
+		if err != nil {
+			return fmt.Errorf("invalid --pre-reboot-node-labels: %w", err)
+		}
+		preRebootNodeLabelKeys = append(preRebootNodeLabelKeys, key)
 	}
 	for _, label := range postRebootNodeLabels {
-		postRebootNodeLabelKeys = append(postRebootNodeLabelKeys, strings.Split(label, "=")[0])
+		key, _, err := splitNodeLabel(label)
+		if err != nil {
+			return fmt.Errorf("invalid --post-reboot-node-labels: %w", err)
+		}
+		postRebootNodeLabelKeys = append(postRebootNodeLabelKeys, key)
 	}
 	sort.Strings(preRebootNodeLabelKeys)
 	sort.Strings(postRebootNodeLabelKeys)
@@ -537,8 +559,11 @@ func deleteNodeAnnotation(client *kubernetes.Clientset, nodeID, key string) erro
 func updateNodeLabels(client *kubernetes.Clientset, node *v1.Node, labels []string) {
 	labelsMap := make(map[string]string)
 	for _, label := range labels {
-		k := strings.Split(label, "=")[0]
-		v := strings.Split(label, "=")[1]
+		k, v, err := splitNodeLabel(label)
+		if err != nil {
+			log.Errorf("Skipping node %s label: %v", node.GetName(), err)
+			continue
+		}
 		labelsMap[k] = v
 		log.Infof("Updating node %s label: %s=%s", node.GetName(), k, v)
 	}
@@ -556,8 +581,10 @@ func updateNodeLabels(client *kubernetes.Clientset, node *v1.Node, labels []stri
 	if err != nil {
 		var labelsErr string
 		for _, label := range labels {
-			k := strings.Split(label, "=")[0]
-			v := strings.Split(label, "=")[1]
+			k, v, splitErr := splitNodeLabel(label)
+			if splitErr != nil {
+				continue
+			}
 			labelsErr += fmt.Sprintf("%s=%s ", k, v)
 		}
 		log.Errorf("Error updating node labels %s via k8s API: %v", labelsErr, err)

--- a/cmd/kured/main_test.go
+++ b/cmd/kured/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -30,48 +31,66 @@ func TestValidateNotificationURL(t *testing.T) {
 }
 
 func TestValidateNodeLabels(t *testing.T) {
+	// wantErr is the sentinel the returned error should wrap (nil means the
+	// input is valid). A malformed label is fatal at startup, a key mismatch is
+	// only a warning, so the caller distinguishes them via errors.Is and the
+	// test pins down which sentinel each case yields.
 	tests := []struct {
-		name        string
-		preReboot   []string
-		postReboot  []string
-		expectError bool
+		name       string
+		preReboot  []string
+		postReboot []string
+		wantErr    error
 	}{
 		{
-			name:        "matching key=value labels are accepted",
-			preReboot:   []string{"maintenance=true"},
-			postReboot:  []string{"maintenance=false"},
-			expectError: false,
+			name:       "matching key=value labels are accepted",
+			preReboot:  []string{"maintenance=true"},
+			postReboot: []string{"maintenance=false"},
+			wantErr:    nil,
 		},
 		{
-			name:        "empty label value is accepted",
-			preReboot:   []string{"maintenance="},
-			postReboot:  []string{"maintenance="},
-			expectError: false,
+			name:       "empty label value is accepted",
+			preReboot:  []string{"maintenance="},
+			postReboot: []string{"maintenance="},
+			wantErr:    nil,
 		},
 		{
-			name:        "label without = is rejected instead of panicking",
-			preReboot:   []string{"node.kubernetes.io/exclude-from-external-load-balancers-"},
-			postReboot:  []string{"node.kubernetes.io/exclude-from-external-load-balancers-"},
-			expectError: true,
+			name:       "label without = is malformed instead of panicking",
+			preReboot:  []string{"node.kubernetes.io/exclude-from-external-load-balancers-"},
+			postReboot: []string{"node.kubernetes.io/exclude-from-external-load-balancers-"},
+			wantErr:    errMalformedNodeLabel,
 		},
 		{
-			name:        "label with empty key is rejected",
-			preReboot:   []string{"=true"},
-			postReboot:  []string{"=true"},
-			expectError: true,
+			name:       "label with empty key is malformed",
+			preReboot:  []string{"=true"},
+			postReboot: []string{"=true"},
+			wantErr:    errMalformedNodeLabel,
 		},
 		{
-			name:        "mismatched keys are rejected",
-			preReboot:   []string{"maintenance=true"},
-			postReboot:  []string{"other=false"},
-			expectError: true,
+			name:       "mismatched keys are reported as a mismatch",
+			preReboot:  []string{"maintenance=true"},
+			postReboot: []string{"other=false"},
+			wantErr:    errMismatchedNodeLabelKeys,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateNodeLabels(tt.preReboot, tt.postReboot)
-			if (err != nil) != tt.expectError {
-				t.Errorf("validateNodeLabels() error = %v, expectError %v", err, tt.expectError)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("validateNodeLabels() = %v, want nil", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("validateNodeLabels() = %v, want error wrapping %v", err, tt.wantErr)
+			}
+			// A malformed label must not be mistaken for a mere mismatch (which
+			// would only warn) and vice versa.
+			if tt.wantErr == errMalformedNodeLabel && errors.Is(err, errMismatchedNodeLabelKeys) {
+				t.Errorf("validateNodeLabels() = %v, malformed label must not wrap errMismatchedNodeLabelKeys", err)
+			}
+			if tt.wantErr == errMismatchedNodeLabelKeys && errors.Is(err, errMalformedNodeLabel) {
+				t.Errorf("validateNodeLabels() = %v, key mismatch must not wrap errMalformedNodeLabel", err)
 			}
 		})
 	}

--- a/cmd/kured/main_test.go
+++ b/cmd/kured/main_test.go
@@ -29,6 +29,54 @@ func TestValidateNotificationURL(t *testing.T) {
 	}
 }
 
+func TestValidateNodeLabels(t *testing.T) {
+	tests := []struct {
+		name        string
+		preReboot   []string
+		postReboot  []string
+		expectError bool
+	}{
+		{
+			name:        "matching key=value labels are accepted",
+			preReboot:   []string{"maintenance=true"},
+			postReboot:  []string{"maintenance=false"},
+			expectError: false,
+		},
+		{
+			name:        "empty label value is accepted",
+			preReboot:   []string{"maintenance="},
+			postReboot:  []string{"maintenance="},
+			expectError: false,
+		},
+		{
+			name:        "label without = is rejected instead of panicking",
+			preReboot:   []string{"node.kubernetes.io/exclude-from-external-load-balancers-"},
+			postReboot:  []string{"node.kubernetes.io/exclude-from-external-load-balancers-"},
+			expectError: true,
+		},
+		{
+			name:        "label with empty key is rejected",
+			preReboot:   []string{"=true"},
+			postReboot:  []string{"=true"},
+			expectError: true,
+		},
+		{
+			name:        "mismatched keys are rejected",
+			preReboot:   []string{"maintenance=true"},
+			postReboot:  []string{"other=false"},
+			expectError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNodeLabels(tt.preReboot, tt.postReboot)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateNodeLabels() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
 func Test_stripQuotes(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This fixes the crash in #1281. If a pre- or post-reboot node label is passed without an `=` (the reporter used a bare `node.kubernetes.io/exclude-from-external-load-balancers-`), `updateNodeLabels` does `strings.Split(label, "=")[1]` on a single-element slice and panics with an index out of range, taking kured down right after the node is uncordoned.

I moved the label parsing to `SplitN` and made `validateNodeLabels` reject anything that isn't in `key=value` form, so a bad value is caught at startup instead of mid-reboot where it can strand a node. `updateNodeLabels` now skips a malformed entry rather than panicking as a second line of defense. Empty values like `key=` are still accepted since Kubernetes allows empty label values. I kept this to the panic itself; the label-removal syntax the reporter was reaching for (a trailing `-`) is a separate feature and out of scope here.

Added a `TestValidateNodeLabels` table covering the no-`=` and empty-key cases; it fails on main today and passes with the fix, and `go test ./cmd/kured/...` is green. Thanks for taking a look.
