### PR TITLE
main: skip invalid node labels instead of panicking in updateNodeLabels

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -534,11 +534,17 @@ func deleteNodeAnnotation(client *kubernetes.Clientset, nodeID, key string) erro
 	return nil
 }
 
-func updateNodeLabels(client *kubernetes.Clientset, node *v1.Node, labels []string) {
+func updateNodeLabels(client kubernetes.Interface, node *v1.Node, labels []string) {
 	labelsMap := make(map[string]string)
 	for _, label := range labels {
-		k := strings.Split(label, "=")[0]
-		v := strings.Split(label, "=")[1]
+		parts := strings.SplitN(label, "=", 2)
+		if len(parts) != 2 {
+			// Labels are added as key=value; skip malformed entries
+			// (e.g. a trailing "-" removal marker) instead of panicking.
+			log.Warnf("Skipping node label %q: expected key=value format", label)
+			continue
+		}
+		k, v := parts[0], parts[1]
 		labelsMap[k] = v
 		log.Infof("Updating node %s label: %s=%s", node.GetName(), k, v)
 	}
@@ -556,9 +562,11 @@ func updateNodeLabels(client *kubernetes.Clientset, node *v1.Node, labels []stri
 	if err != nil {
 		var labelsErr string
 		for _, label := range labels {
-			k := strings.Split(label, "=")[0]
-			v := strings.Split(label, "=")[1]
-			labelsErr += fmt.Sprintf("%s=%s ", k, v)
+			parts := strings.SplitN(label, "=", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			labelsErr += fmt.Sprintf("%s=%s ", parts[0], parts[1])
 		}
 		log.Errorf("Error updating node labels %s via k8s API: %v", labelsErr, err)
 	}

--- a/cmd/kured/main_test.go
+++ b/cmd/kured/main_test.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/api/core/v1"
 )
 
 func TestValidateNotificationURL(t *testing.T) {
@@ -73,4 +80,27 @@ func Test_stripQuotes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateNodeLabelsSkipsInvalidEntries(t *testing.T) {
+	client := fake.NewSimpleClientset(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+	})
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node"}}
+
+	// A trailing "-" removal marker (no "=") previously panicked with
+	// "index out of range [1] with length 1". It must now be skipped.
+	labels := []string{
+		"node.kubernetes.io/exclude-from-external-load-balancers=foo",
+		"node.kubernetes.io/exclude-from-external-load-balancers-",
+	}
+	require.NotPanics(t, func() {
+		updateNodeLabels(client, node, labels)
+	})
+
+	updated, err := client.CoreV1().Nodes().Get(context.TODO(), "test-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "foo", updated.Labels["node.kubernetes.io/exclude-from-external-load-balancers"])
+	_, hasInvalid := updated.Labels["node.kubernetes.io/exclude-from-external-load-balancers-"]
+	assert.False(t, hasInvalid, "invalid label entry should not be applied")
 }


### PR DESCRIPTION
updateNodeLabels indexed the key=value split with [1], so a label entry without an equals sign (e.g. a trailing "-" removal marker in post-reboot-node-labels) panicked the daemon during uncordon and crashed the node reboot loop. Skip malformed entries with a warning instead of panicking.

Used AI to help identify and draft this fix — reviewed and tested before submitting.