### PR TITLE
Bump codeql together

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
   # Maintain dependencies for gomod
   - package-ecosystem: "gomod"
     directory: "/"


### PR DESCRIPTION
Without this, multiple codeql actions are bumped separately, and there is a risk of failure like in [0][1][2].

[0]: https://github.com/kubereboot/kured/pull/1381
[1]: https://github.com/kubereboot/kured/pull/1384
[2]: https://github.com/kubereboot/kured/pull/1386