### PR TITLE
Add cooldowns to dependabots

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,11 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   # Maintain dependencies for gomod
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      semver-minor-days: 7
     groups:
       all:
         patterns:


### PR DESCRIPTION
To avoid wrong bumps that are quickly fixed, or supply chain attacks, we might want to have a grace period in all our dependabot updates.

This introduces it.