### PR TITLE
fix CVE-2026-39822

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 actionlint = "latest"
 cosign = "3.0.6"
-go = "1.26.4"
+go = "1.26.5"
 golangci-lint = "2.12.2"
 goreleaser = "2.16.0"
 kind = "0.32.0"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubereboot/kured
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/containrrr/shoutrrr v0.8.0


### PR DESCRIPTION
Without this, trivy will fail.