### PR TITLE
Uncordon node before releasing lock after a failed drain

### DIFF
--- a/cmd/kured/main.go
+++ b/cmd/kured/main.go
@@ -479,6 +479,19 @@ func uncordon(client *kubernetes.Clientset, node *v1.Node) error {
 	return nil
 }
 
+// uncordonThenRelease performs a best-effort uncordon before releasing the lock, so that a
+// failed drain does not leave the node cordoned for the duration of any configured lock
+// release delay.
+func uncordonThenRelease(nodeName string, lock daemonsetlock.Lock, uncordonFn func() error) {
+	log.Infof("Performing a best-effort uncordon after failed cordon and drain")
+	if err := uncordonFn(); err != nil {
+		log.Errorf("Failed to uncordon %s: %v", nodeName, err)
+	}
+	if err := lock.Release(); err != nil {
+		log.Errorf("Error releasing lock: %v", err)
+	}
+}
+
 func maintainRebootRequiredMetric(nodeID string, checker checkers.Checker) {
 	for {
 		if checker.RebootRequired() {
@@ -690,15 +703,7 @@ func rebootAsRequired(nodeID string, rebooter reboot.Rebooter, checker checkers.
 		if err != nil {
 			if !forceReboot {
 				log.Errorf("Unable to cordon or drain %s: %v, will release lock and retry cordon and drain before rebooting when lock is next acquired", node.GetName(), err)
-				err = lock.Release()
-				if err != nil {
-					log.Errorf("Error releasing lock: %v", err)
-				}
-				log.Infof("Performing a best-effort uncordon after failed cordon and drain")
-				err := uncordon(client, node)
-				if err != nil {
-					log.Errorf("Failed to uncordon %s: %v", node.GetName(), err)
-				}
+				uncordonThenRelease(node.GetName(), lock, func() error { return uncordon(client, node) })
 				continue
 			}
 		}

--- a/cmd/kured/main_test.go
+++ b/cmd/kured/main_test.go
@@ -1,9 +1,56 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/kubereboot/kured/pkg/daemonsetlock"
 )
+
+// fakeLock is a minimal daemonsetlock.Lock used to observe call ordering in tests.
+type fakeLock struct {
+	onRelease func()
+}
+
+func (f *fakeLock) Acquire(daemonsetlock.NodeMeta) (bool, string, error) { return true, "", nil }
+func (f *fakeLock) Holding() (bool, daemonsetlock.LockAnnotationValue, error) {
+	return true, daemonsetlock.LockAnnotationValue{}, nil
+}
+func (f *fakeLock) Release() error {
+	if f.onRelease != nil {
+		f.onRelease()
+	}
+	return nil
+}
+
+func TestUncordonThenReleaseUncordonsBeforeReleasingLock(t *testing.T) {
+	var order []string
+
+	lock := &fakeLock{onRelease: func() { order = append(order, "release") }}
+	uncordonFn := func() error {
+		order = append(order, "uncordon")
+		return nil
+	}
+
+	uncordonThenRelease("test-node", lock, uncordonFn)
+
+	if want := []string{"uncordon", "release"}; !reflect.DeepEqual(order, want) {
+		t.Errorf("uncordonThenRelease() call order = %v, want %v", order, want)
+	}
+}
+
+func TestUncordonThenReleaseReleasesLockEvenIfUncordonFails(t *testing.T) {
+	released := false
+	lock := &fakeLock{onRelease: func() { released = true }}
+	uncordonFn := func() error { return errors.New("boom") }
+
+	uncordonThenRelease("test-node", lock, uncordonFn)
+
+	if !released {
+		t.Errorf("uncordonThenRelease() did not release the lock after a failed uncordon")
+	}
+}
 
 func TestValidateNotificationURL(t *testing.T) {
 


### PR DESCRIPTION
Motivation:
When a node fails to drain and forceReboot is disabled, kured releases
the lock and then performs a best-effort uncordon so the node can keep
receiving workloads. Both DaemonSetSingleLock.Release() and
DaemonSetMultiLock.Release() (pkg/daemonsetlock/daemonsetlock.go) sleep
for the configured --lock-release-delay before doing anything else.
Because uncordon was called only after lock.Release() returned, the
node stayed cordoned for the entire release delay even though no
reboot was going to happen, defeating the purpose of a best-effort
uncordon on drain failure. This regressed behavior present before
commit 104a745305e02d85ce1555b7d2c7d1f44cab1ccf, which moved the
release delay into Release() without reordering the caller.

Approach:
Extract the drain-failure handling in rebootAsRequired into a new
uncordonThenRelease helper (cmd/kured/main.go) that uncordons the node
first and only then releases the lock, so the release delay no longer
blocks the uncordon. The lock is still released even if uncordon
fails, matching the previous error-handling behaviour.

Validation:
- go build ./...
- make test (lint-sh, lint-ghactions, golangci-lint, and
  `go test -test.short ./...`) passes with 0 lint issues and 0 test
  failures.
- Added TestUncordonThenReleaseUncordonsBeforeReleasingLock and
  TestUncordonThenReleaseReleasesLockEvenIfUncordonFails
  (cmd/kured/main_test.go), using a minimal fake daemonsetlock.Lock to
  assert call order. Confirmed these are a real regression test: with
  the order in uncordonThenRelease temporarily reverted to
  release-then-uncordon, TestUncordonThenReleaseUncordonsBeforeReleasingLock
  fails ("call order = [release uncordon], want [uncordon release]");
  restoring the fix makes it pass again.
- Not run: the kind-based e2e suite (make e2e-test), which needs a
  local kind/docker cluster not available in this environment.
  CONTRIBUTING.md describes e2e tests as encouraged for functional
  testing, not required for a fix of this size, and `make test` is the
  documented CI-mirroring command.

Report: https://github.com/kubereboot/kured/issues/1129
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #1129