### PR TITLE
fix(lock): fall back to configured TTL for locks that recorded none

### DIFF
--- a/pkg/daemonsetlock/daemonsetlock.go
+++ b/pkg/daemonsetlock/daemonsetlock.go
@@ -150,7 +150,7 @@ func (dsl *DaemonSetSingleLock) Acquire(nodeMetadata NodeMeta) (bool, string, er
 				return false, "", err
 			}
 
-			if !ttlExpired(value.Created, value.TTL) {
+			if !ttlExpired(value.Created, effectiveTTL(value.TTL, dsl.TTL)) {
 				return value.NodeID == dsl.nodeID, value.NodeID, nil
 			}
 		}
@@ -201,7 +201,7 @@ func (dsl *DaemonSetSingleLock) Holding() (bool, LockAnnotationValue, error) {
 			return false, lockData, err
 		}
 
-		if !ttlExpired(value.Created, value.TTL) {
+		if !ttlExpired(value.Created, effectiveTTL(value.TTL, dsl.TTL)) {
 			return value.NodeID == dsl.nodeID, value, nil
 		}
 	}
@@ -257,6 +257,25 @@ func ttlExpired(created time.Time, ttl time.Duration) bool {
 	return false
 }
 
+// effectiveTTL decides which TTL an existing lock is judged by.
+//
+// A lock records the TTL that was configured when it was taken. Since
+// --lock-ttl defaults to 0 and ttlExpired never expires a zero TTL, a lock
+// taken before the flag was set can outlive the node that took it: the node
+// is gone and cannot release, and no later value of --lock-ttl reaches the
+// TTL already written into the annotation. Reboots then block until an
+// operator deletes the annotation by hand.
+//
+// Falling back to the configured TTL only when the lock recorded none keeps
+// locks that carry their own TTL on that TTL, so a rolling upgrade still sees
+// each lock honour the setting it was taken under.
+func effectiveTTL(stored, configured time.Duration) time.Duration {
+	if stored == 0 {
+		return configured
+	}
+	return stored
+}
+
 func nodeIDsFromMultiLock(annotation multiLockAnnotationValue) []string {
 	nodeIDs := make([]string, 0, len(annotation.LockAnnotations))
 	for _, nodeLock := range annotation.LockAnnotations {
@@ -273,7 +292,7 @@ func (dsl *DaemonSetLock) canAcquireMultiple(annotation multiLockAnnotationValue
 		newAnnotation.LockAnnotations = annotation.LockAnnotations
 	} else {
 		for _, nodeLock := range annotation.LockAnnotations {
-			if ttlExpired(nodeLock.Created, nodeLock.TTL) {
+			if ttlExpired(nodeLock.Created, effectiveTTL(nodeLock.TTL, TTL)) {
 				freeSpace = true
 				continue
 			}
@@ -359,7 +378,7 @@ func (dsl *DaemonSetMultiLock) Holding() (bool, LockAnnotationValue, error) {
 		}
 
 		for _, nodeLock := range value.LockAnnotations {
-			if nodeLock.NodeID == dsl.nodeID && !ttlExpired(nodeLock.Created, nodeLock.TTL) {
+			if nodeLock.NodeID == dsl.nodeID && !ttlExpired(nodeLock.Created, effectiveTTL(nodeLock.TTL, dsl.TTL)) {
 				return true, nodeLock, nil
 			}
 		}

--- a/pkg/daemonsetlock/daemonsetlock_test.go
+++ b/pkg/daemonsetlock/daemonsetlock_test.go
@@ -29,6 +29,27 @@ func TestTtlExpired(t *testing.T) {
 	}
 }
 
+func TestEffectiveTTL(t *testing.T) {
+	tests := []struct {
+		name       string
+		stored     time.Duration
+		configured time.Duration
+		want       time.Duration
+	}{
+		{"lock recorded its own ttl, configured ignored", time.Hour, time.Minute, time.Hour},
+		{"lock recorded none, falls back to configured", 0, 30 * time.Minute, 30 * time.Minute},
+		{"neither set, stays disabled", 0, 0, 0},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			if got := effectiveTTL(tst.stored, tst.configured); got != tst.want {
+				t.Errorf("effectiveTTL(%v, %v) = %v, want %v", tst.stored, tst.configured, got, tst.want)
+			}
+		})
+	}
+}
+
 func multiLockAnnotationsAreEqualByNodes(src, dst multiLockAnnotationValue) bool {
 	srcNodes := []string{}
 	for _, srcLock := range src.LockAnnotations {
@@ -178,6 +199,40 @@ func TestCanAcquireMultiple(t *testing.T) {
 				MaxOwners: 2,
 				LockAnnotations: []LockAnnotationValue{
 					{NodeID: node1Name},
+				},
+			},
+			lockPossible: true,
+		},
+		{
+			// A lock taken while --lock-ttl was still at its default of 0
+			// records a zero TTL. Without a fallback to the configured TTL
+			// that lock never expires, so a node that went away without
+			// releasing blocks every later reboot.
+			name: "full_with_lock_taken_before_ttl_was_configured",
+			daemonSetLock: DaemonSetLock{
+				nodeID: node1Name,
+			},
+			maxOwners: 2,
+			current: multiLockAnnotationValue{
+				MaxOwners: 2,
+				LockAnnotations: []LockAnnotationValue{
+					{
+						NodeID:  node2Name,
+						Created: time.Now().UTC().Add(-1 * time.Hour),
+						TTL:     0,
+					},
+					{
+						NodeID:  node3Name,
+						Created: time.Now().UTC().Add(-1 * time.Minute),
+						TTL:     time.Hour,
+					},
+				},
+			},
+			desired: multiLockAnnotationValue{
+				MaxOwners: 2,
+				LockAnnotations: []LockAnnotationValue{
+					{NodeID: node1Name},
+					{NodeID: node3Name},
 				},
 			},
 			lockPossible: true,


### PR DESCRIPTION
Fixes #822

## The problem

A lock annotation stores the TTL that was configured at the moment the lock was taken:

```go
value := LockAnnotationValue{
    NodeID:   dsl.nodeID,
    Metadata: nodeMetadata,
    Created:  time.Now().UTC(),
    TTL:      dsl.TTL,
}
```

Every later expiry check then judges the lock by that recorded value rather than by the current
configuration, in `DaemonSetSingleLock.Acquire`, `DaemonSetSingleLock.Holding`,
`DaemonSetMultiLock.Holding` and `canAcquireMultiple`.

`--lock-ttl` defaults to `0`, and `ttlExpired` deliberately treats a zero TTL as "never expires":

```go
func ttlExpired(created time.Time, ttl time.Duration) bool {
	if ttl > 0 && time.Since(created) >= ttl {
		return true
	}
	return false
}
```

Put together, a lock taken before `--lock-ttl` was set records `TTL: 0` and can never expire.
Setting `--lock-ttl` afterwards does not help, because the flag only affects locks taken from that
point on; it never reaches the zero already written into the annotation. If the node holding that
lock goes away without releasing, which is what happens when the cluster autoscaler removes it,
the lock outlives the node and every subsequent reboot blocks until an operator deletes the
annotation by hand.

That is the second report on #822: the lock predated the setting, `lockTtl: 30m` was added
afterwards, and days later the annotation still had to be removed manually.

## Reproduction

`canAcquireMultiple` is a pure function, so this needs no cluster. A 48 hour old lock held by a
node that is gone, with the operator having since configured a 30 minute TTL:

```
stored TTL=0,   configured TTL=30m, lock 48h old -> acquirable=false
stored TTL=30m, configured TTL=30m, lock 48h old -> acquirable=true
```

The only difference between the two lines is what the annotation happened to record when it was
written. The first case is unrecoverable without manual intervention.

## The change

Judge an existing lock by its own TTL when it recorded one, and by the currently configured TTL
when it did not:

```go
func effectiveTTL(stored, configured time.Duration) time.Duration {
	if stored == 0 {
		return configured
	}
	return stored
}
```

I deliberately kept this narrow rather than always preferring the configured value. Locks that
carry a TTL keep being judged by it, so during a rolling upgrade each lock still honours the
setting it was taken under, and the only behaviour that changes is the case that is currently
unrecoverable. If you would rather the configured TTL always win, that is a one line change and I
am happy to make it.

## Testing

`TestCanAcquireMultiple` gains a `full_with_lock_taken_before_ttl_was_configured` case. It fails
on unpatched `main`:

```
--- FAIL: TestCanAcquireMultiple/full_with_lock_taken_before_ttl_was_configured
    daemonsetlock_test.go:246: unexpected result for lock possible (got false expected true
```

and passes with the change. The five pre-existing cases are untouched and still pass, as does
`TestTtlExpired`. `TestEffectiveTTL` covers the helper directly, including the both-zero case
where locking stays disabled as before.

`gofmt`, `go vet ./...` and `go build ./...` are clean, and `go test ./pkg/... ./cmd/...` passes.

I kept this to unit tests rather than adding an e2e case. Reproducing it end to end means taking
a lock, removing the node that holds it, and then restarting kured with a different `--lock-ttl`,
which is a fair amount of machinery for something the pure functions already demonstrate. Glad to
add one if you would prefer the coverage.

## One thing I could not confirm

The change explains the second report on #822 exactly. I could not reproduce the original
reporter's case from the issue text: their annotation shows a non-zero TTL, and a lock that
records its own TTL is already reclaimed correctly on the next `Acquire`. So this may be a second
issue rather than the same one, and I did not want to claim the issue is fully closed by this if
it is not. Happy for #822 to stay open if you read it that way.
